### PR TITLE
test(shared): cover vendorOf grouping edge cases (#7)

### DIFF
--- a/src/shared/providerGroups.test.ts
+++ b/src/shared/providerGroups.test.ts
@@ -47,6 +47,18 @@ describe('vendorOf', () => {
     expect(vendorOf({ baseUrl: 'not a url' })).toBe(CUSTOM_VENDOR_ID);
     expect(vendorOf({ baseUrl: '   ' })).toBe(CUSTOM_VENDOR_ID);
   });
+
+  it('IPv6 loopback 归 local', () => {
+    expect(vendorOf({ baseUrl: 'http://[::1]/v1' })).toBe('local');
+  });
+
+  it('baseUrl 带端口时仍按 hostname 归组', () => {
+    expect(vendorOf({ baseUrl: 'https://api.anthropic.com:8443/v1' })).toBe('anthropic');
+  });
+
+  it('oauthAccountKey 两位序号同样反解基础 providerId', () => {
+    expect(vendorOf({ oauthAccountKey: 'anthropic#10', baseUrl: '' })).toBe('anthropic');
+  });
 });
 
 describe('groupProviders', () => {

--- a/src/shared/providerGroups.ts
+++ b/src/shared/providerGroups.ts
@@ -30,6 +30,8 @@ const VENDOR_BY_HOST: Readonly<Record<string, string>> = {
   'api.mistral.ai': 'mistral',
   localhost: 'local',
   '127.0.0.1': 'local',
+  // WHATWG hostname 对 IPv6 带方括号；::1 与 127.0.0.1 同属 loopback
+  '[::1]': 'local',
 };
 
 /** 后缀表，处理子域形态（顺序无关：命中即返回，键互不为前缀） */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #7.

Adds the three `vendorOf` grouping edge cases called out in review (non-blocking):

1. **IPv6 loopback → `local`** — `http://[::1]/v1`. WHATWG `URL.hostname` yields `[::1]`, which was missing from `VENDOR_BY_HOST` (only `localhost` / `127.0.0.1` were mapped). Smallest production change: add that host to the local table.
2. **baseUrl with a port** — `https://api.anthropic.com:8443/v1` still groups as `anthropic`. Implementation already used `hostname` (port lives on `URL.port`); no production change.
3. **`oauthAccountKey` like `anthropic#10`** — two-digit sequence still resolves to `anthropic`. `providerIdOfAccountKey` slices at the first `#`; no production change.

## Verification

```bash
pnpm exec vitest run src/shared/providerGroups.test.ts
```

Result: 15 passed (12 existing + 3 new). Biome check on the two files is clean. No CDP / Electron UI — unit tests only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61356968-2b7c-42f2-bb82-556bd93e34c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61356968-2b7c-42f2-bb82-556bd93e34c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

