### PR TITLE
chore(tooling): ignore .hce in biome.json (#9)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -60,6 +60,7 @@
       "!.cursor",
       "!.omp",
       "!.pi",
+      "!.hce",
       "!temp"
     ]
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #9.

`.hce` is a local code-search index. It was only excluded via `.git/info/exclude`, so a fresh clone still failed `biome check .` on `.hce/config.json` and `.hce/index.json`.

This adds `!.hce` to `files.includes` in `biome.json`, same style as the other tool-output folders (`.trellis`, `.agents`, `.cursor`, etc.). The whole directory is ignored, not just those two filenames. No lint-rule, format, or app-code changes.

## Verification

- `pnpm i` (Biome was not installed in this environment)
- `pnpm exec biome check .` — no `.hce` diagnostics. Remaining 12 errors / 3 warnings / 2 infos are pre-existing on `dev` (format/lint in app files, plus the `recommended` deprecation info). This PR does not touch those files.
- Reproduced the #9 failure on `dev`’s `biome.json`: `biome check .hce/config.json .hce/index.json` reports parse/format errors.
- Same paths on this branch: Biome reports “These paths were provided but ignored: `.hce/config.json`, `.hce/index.json`”.

CDP / UI verification does not apply: this is a tooling ignore only. Do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27b0b4bf-64e8-40bf-9ade-7d5dcd3b0bd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27b0b4bf-64e8-40bf-9ade-7d5dcd3b0bd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

