### PR TITLE
fix(providers): cap plan and usage-window labels (#12)

### DIFF
--- a/.trellis/spec/shared/types.md
+++ b/.trellis/spec/shared/types.md
@@ -99,3 +99,14 @@ export interface McpCandidate {
 ```
 
 新增扫描来源时保持这个切分，不要图省事把明文塞进候选类型。
+
+## 厂商短文案必须上游限长
+
+`OauthAccount.plan` 和 `OauthUsageWindow.label` 来自厂商 JWT / 额度接口，
+长度不受我们控制。渲染侧（ModelPicker 16、状态栏 24）已经截断展示，
+但探测结果还会写入 sidecar 并经 IPC 下发，所以**生产这些字段的探测路径
+必须走 `sanitizeOauthLabel`**（上限 `OAUTH_LABEL_MAX_LENGTH` = 32）。
+
+新探测不要把厂商原文直接赋给 `plan` / `label`。不要再写一份截断函数，
+也不要把展示截断上移成第二个事实源——渲染侧的 truncate 是布局兜底，
+上游限长是写盘 / IPC 兜底，两层都留着。

--- a/src/main/services/oauthProviders.test.ts
+++ b/src/main/services/oauthProviders.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import type { OauthLoginEvent } from '@shared/types';
+import { OAUTH_LABEL_MAX_LENGTH, type OauthLoginEvent } from '@shared/types';
 import type { WebContents } from 'electron';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -127,6 +127,28 @@ describe('listOauthProviders 的账号枚举', () => {
       { key: 'google-antigravity', providerId: 'google-antigravity', email: 'ag@example.com' },
     ]);
   });
+
+  it('JWT 里超长 plan 按共享上限截断', async () => {
+    const restore = withAuthJson((parsed) => {
+      parsed['openai-codex'] = {
+        type: 'oauth',
+        access: fakeJwt({
+          email: 'huge@example.com',
+          'https://api.openai.com/auth': { chatgpt_plan_type: 'P'.repeat(200) },
+        }),
+        refresh: 'r3',
+        expires,
+      };
+    });
+    try {
+      const { listOauthProviders } = await import('./oauthProviders');
+      const providers = await listOauthProviders();
+      const codex = providers.find((provider) => provider.id === 'openai-codex');
+      expect(codex?.accounts[0]?.plan).toBe('P'.repeat(OAUTH_LABEL_MAX_LENGTH));
+    } finally {
+      restore();
+    }
+  });
 });
 
 /** 收集 OAUTH_LOGIN_EVENT 的假 WebContents */
@@ -248,6 +270,34 @@ describe('Antigravity 额度探测', () => {
     expect(seenAuth).toContain('Bearer ya29.access-token');
     expect(seenAuth.some((value) => value.includes('projectId'))).toBe(false);
     fetchSpy.mockRestore();
+  });
+
+  it('厂商 windowLabel 超长时按共享上限截断', async () => {
+    const { getOauthAccountUsage } = await import('./oauthProviders');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          models: {
+            'gemini-3-pro': {
+              quotaInfo: {
+                remainingFraction: 0.4,
+                resetTime: new Date(expires).toISOString(),
+                windowLabel: 'W'.repeat(200),
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    });
+    try {
+      const usage = await getOauthAccountUsage('google-antigravity');
+      expect(usage.error).toBeUndefined();
+      expect(usage.windows).toHaveLength(1);
+      expect(usage.windows[0]?.label).toBe('W'.repeat(OAUTH_LABEL_MAX_LENGTH));
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('凭证缺 projectId 时落到 error 而不是静默空窗口', async () => {

--- a/src/main/services/oauthProviders.ts
+++ b/src/main/services/oauthProviders.ts
@@ -22,7 +22,7 @@ import type {
   OauthProviderInfo,
   OauthUsageWindow,
 } from '@shared/types';
-import { IPC_CHANNELS, providerIdOfAccountKey } from '@shared/types';
+import { IPC_CHANNELS, providerIdOfAccountKey, sanitizeOauthLabel } from '@shared/types';
 import { app, shell, type WebContents } from 'electron';
 
 // pi-ai 不在依赖树顶层，auth 交互类型从 ModelRuntime.login 签名结构化提取
@@ -201,12 +201,18 @@ function identityFromCredential(providerId: string, access: string): AccountIden
   if (typeof claims.email === 'string') identity.email = claims.email;
   if (providerId === 'openai-codex') {
     const planType = obj(claims['https://api.openai.com/auth']).chatgpt_plan_type;
-    if (typeof planType === 'string') identity.plan = planType;
+    if (typeof planType === 'string') assignPlan(identity, planType);
   } else if (providerId === 'xai') {
     const tier = claims.tier;
-    if (typeof tier === 'number' || typeof tier === 'string') identity.plan = `tier ${tier}`;
+    if (typeof tier === 'number' || typeof tier === 'string') assignPlan(identity, `tier ${tier}`);
   }
   return identity;
+}
+
+/** 空串视为没有档位，避免控制字符被洗掉后还留下一个空白 plan */
+function assignPlan(identity: AccountIdentity, raw: string): void {
+  const plan = sanitizeOauthLabel(raw);
+  if (plan) identity.plan = plan;
 }
 
 /** auth.json 里属于某基础 provider 的账号 key，按 key 排序 */
@@ -590,7 +596,7 @@ async function codexProbe(
       resetsAt: toEpochMs(window.reset_at),
     });
   }
-  if (typeof data.plan_type === 'string') probe.plan = data.plan_type;
+  if (typeof data.plan_type === 'string') assignPlan(probe, data.plan_type);
   return probe;
 }
 
@@ -809,7 +815,21 @@ async function probeAccount(runtime: ModelRuntimeType, accountKey: string): Prom
               ? await antigravityProbe(token)
               : { windows: [] as OauthUsageWindow[] };
   // 网络结果优先，缺的字段用 token 里读到的兜底
-  return { ...fromToken, ...probe };
+  return sanitizeAccountProbe({ ...fromToken, ...probe });
+}
+
+/** 所有探测出口过同一道限长，避免某个厂商忘了在赋值处调用 sanitizeOauthLabel */
+function sanitizeAccountProbe(probe: AccountProbe): AccountProbe {
+  const { plan: rawPlan, windows, ...rest } = probe;
+  const plan = rawPlan !== undefined ? sanitizeOauthLabel(rawPlan) : '';
+  return {
+    ...rest,
+    ...(plan ? { plan } : {}),
+    windows: windows.map((window) => ({
+      ...window,
+      label: sanitizeOauthLabel(window.label),
+    })),
+  };
 }
 
 /** 身份探测：登录成功后写 sidecar 用，额度部分丢弃 */

--- a/src/shared/providers/antigravity.test.ts
+++ b/src/shared/providers/antigravity.test.ts
@@ -1,3 +1,4 @@
+import { OAUTH_LABEL_MAX_LENGTH } from '@shared/types';
 import { describe, expect, it } from 'vitest';
 import {
   ANTIGRAVITY_FALLBACK_MODELS,
@@ -325,6 +326,26 @@ describe('parseUsageWindows', () => {
     expect(windows).toEqual([
       { label: 'Google Daily', usedPercent: 100, resetsAt: Date.parse('2026-01-01T06:00:00Z') },
     ]);
+  });
+
+  it('厂商 windowLabel 超长时按共享上限截断', () => {
+    const windows = parseUsageWindows(
+      {
+        models: {
+          a: {
+            quotaInfo: {
+              remainingFraction: 0.5,
+              resetTime: '2026-01-01T06:00:00Z',
+              windowLabel: 'X'.repeat(200),
+            },
+          },
+        },
+      },
+      now
+    );
+    expect(windows).toHaveLength(1);
+    expect(windows[0]?.label).toHaveLength(OAUTH_LABEL_MAX_LENGTH);
+    expect(windows[0]?.label).toBe('X'.repeat(OAUTH_LABEL_MAX_LENGTH));
   });
 
   it.each([

--- a/src/shared/providers/antigravity.ts
+++ b/src/shared/providers/antigravity.ts
@@ -11,7 +11,7 @@
  * 不引入额外校验依赖；运行时校验用手写窄化函数完成。
  */
 import { randomBytes, randomUUID } from 'node:crypto';
-import type { OauthUsageWindow } from '@shared/types';
+import { type OauthUsageWindow, sanitizeOauthLabel } from '@shared/types';
 import { startOauthCallbackServer } from './callbackServer';
 import {
   createEventStream,
@@ -1825,9 +1825,10 @@ function quotaLabel(entry: QuotaEntry, resetsAt: number | undefined, nowMs: numb
         ? 'OpenAI'
         : '';
   // 后端很少给 windowLabel，按 resetTime 距今是否超过一天区分 daily / weekly
-  const window =
-    entry.windowLabel ?? (resetsAt !== undefined && resetsAt - nowMs > DAY_MS ? 'Weekly' : 'Daily');
-  return vendor ? `${vendor} ${window}` : window;
+  const fallback = resetsAt !== undefined && resetsAt - nowMs > DAY_MS ? 'Weekly' : 'Daily';
+  const window = entry.windowLabel ?? fallback;
+  const raw = vendor ? `${vendor} ${window}` : window;
+  return sanitizeOauthLabel(raw) || fallback;
 }
 
 function collectQuotas(entry: Record<string, unknown>): QuotaEntry[] {

--- a/src/shared/types/oauthProviders.test.ts
+++ b/src/shared/types/oauthProviders.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { OAUTH_LABEL_MAX_LENGTH, sanitizeOauthLabel } from './oauthProviders';
+
+describe('sanitizeOauthLabel', () => {
+  it('短文案原样返回', () => {
+    expect(sanitizeOauthLabel('plus')).toBe('plus');
+    expect(sanitizeOauthLabel('Anthropic Weekly')).toBe('Anthropic Weekly');
+  });
+
+  it('去掉控制字符并 trim', () => {
+    expect(sanitizeOauthLabel('\u0000plus\u0007\n')).toBe('plus');
+    expect(sanitizeOauthLabel('  pro  ')).toBe('pro');
+    expect(sanitizeOauthLabel('\u007f\t')).toBe('');
+  });
+
+  it(`超长厂商串硬截到 ${OAUTH_LABEL_MAX_LENGTH}，不加省略号`, () => {
+    const raw = 'P'.repeat(OAUTH_LABEL_MAX_LENGTH + 40);
+    const capped = sanitizeOauthLabel(raw);
+    expect(capped).toHaveLength(OAUTH_LABEL_MAX_LENGTH);
+    expect(capped).toBe('P'.repeat(OAUTH_LABEL_MAX_LENGTH));
+    expect(capped).not.toContain('…');
+  });
+
+  it('刚好等于上限的串不截', () => {
+    const exact = 'E'.repeat(OAUTH_LABEL_MAX_LENGTH);
+    expect(sanitizeOauthLabel(exact)).toBe(exact);
+  });
+});

--- a/src/shared/types/oauthProviders.ts
+++ b/src/shared/types/oauthProviders.ts
@@ -18,7 +18,10 @@ export interface OauthAccount {
   providerId: string;
   /** 账号邮箱，从 JWT claims 或厂商 userinfo 端点 best-effort 取得 */
   email?: string;
-  /** 订阅档位（如 'max'、'pro'） */
+  /**
+   * 订阅档位（如 'max'、'pro'）。
+   * 厂商原文经 `sanitizeOauthLabel` 截到 `OAUTH_LABEL_MAX_LENGTH`。
+   */
   plan?: string;
 }
 
@@ -39,6 +42,9 @@ export interface OauthProviderInfo {
 
 /** 订阅额度窗口（如 Claude 5h/7d、Codex primary/secondary、Antigravity daily/weekly） */
 export interface OauthUsageWindow {
+  /**
+   * 窗口名。厂商原文经 `sanitizeOauthLabel` 截到 `OAUTH_LABEL_MAX_LENGTH`。
+   */
   label: string;
   /** 已用百分比 0-100 */
   usedPercent: number;
@@ -74,6 +80,30 @@ export type OauthLoginEvent =
   /** 登录成功；account 是这次新增（或覆盖）的那个账号 */
   | { type: 'done'; providerId: string; account: OauthAccount }
   | { type: 'error'; message: string };
+
+/**
+ * 厂商 `plan` / `OauthUsageWindow.label` 的上游长度上限。
+ *
+ * 渲染侧：ModelPicker 把 plan 截到 16，状态栏把窗口 label 截到 24。
+ * 这里取 32——略宽于两者，挡住无界厂商串写入 sidecar / IPC，
+ * 又不比界面展示更狠。控制字符一并剔除（与 ModelPicker 的 sanitizeAccountText 同意图）。
+ */
+export const OAUTH_LABEL_MAX_LENGTH = 32;
+
+/**
+ * 探测结果里给界面/sidecar 的短文案：去掉控制字符、trim，再硬截到
+ * `OAUTH_LABEL_MAX_LENGTH`。数据层不加省略号——展示截断仍由渲染侧负责。
+ */
+export function sanitizeOauthLabel(value: string): string {
+  let out = '';
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) continue;
+    out += ch;
+  }
+  out = out.trim();
+  return out.length > OAUTH_LABEL_MAX_LENGTH ? out.slice(0, OAUTH_LABEL_MAX_LENGTH) : out;
+}
 
 /** 首个账号沿用裸 providerId，后续为 `<providerId>#<n>` */
 export const accountKeyFor = (providerId: string, ordinal: number): string =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #12.

Renderer already truncates display (`ModelPicker.sanitizeAccountText` caps plan at 16; status-line overlay caps window labels at 24). This PR is **defense in depth**: upstream probes still returned unbounded `plan` and `OauthUsageWindow.label`, which are written to the sidecar and sent over IPC.

## What changed

- One shared helper: `sanitizeOauthLabel` + `OAUTH_LABEL_MAX_LENGTH = 32` in `src/shared/types/oauthProviders.ts`.
  - 32 is slightly wider than the renderer caps (16 / 24), so we bound vendor strings without being stricter than the UI.
  - Strips control characters, trims, then hard-slices. No ellipsis at the data layer — display truncation stays in the renderer.
- All probe paths use it:
  - Antigravity `quotaLabel` / `parseUsageWindows` (`src/shared/providers/antigravity.ts`)
  - JWT / Codex `plan` assignment and a final `sanitizeAccountProbe` choke point on `probeAccount` (`src/main/services/oauthProviders.ts`)
- Unit tests for the sanitizer, plus probe-path tests that a 200-char vendor `windowLabel` / JWT `plan` is capped at 32.

## Out of scope

- No ModelPicker / Badge UI changes.
- Does not tackle issue #4 (Cursor usage).
- **CDP / browser verification is not required** — there is no UI change.

## Tests

```
pnpm exec vitest run src/shared/types/oauthProviders.test.ts src/shared/providers/antigravity.test.ts src/main/services/oauthProviders.test.ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce592a30-cb73-45e5-ac4b-4f0d37b617a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce592a30-cb73-45e5-ac4b-4f0d37b617a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

