### PR TITLE
fix(settings): McpEditDialog / ProviderEditDialog 下拉触发器渲染映射文案

### DIFF
--- a/.trellis/spec/renderer/dialogs.md
+++ b/.trellis/spec/renderer/dialogs.md
@@ -47,6 +47,10 @@
 <SelectPopup zIndex={Z_INDEX.DROPDOWN_IN_MODAL}>
 ```
 
+弹窗（以及任何）`Select` 必须传 `items`（`Record<value, label>` 或 `{ value, label }[]`）。
+Base UI 的 `SelectValue` 关着 popup 时读不到 `SelectItem` 文案，缺 `items` 就会把原始 value 画在触发器上。
+对照 `GeneralSettings` / `AppearanceSettings` / `McpEditDialog` / `ProviderEditDialog`。
+
 因为 `SelectPopup` 默认用 `Z_INDEX.DROPDOWN`(40)，而 `MODAL_CONTENT` 是 51。
 症状是点开下拉看不见选项。嵌套弹窗里的下拉用 `DROPDOWN_IN_NESTED_MODAL`。
 

--- a/scripts/cdp-issue-8-select-labels.mjs
+++ b/scripts/cdp-issue-8-select-labels.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * CDP check for issue #8: McpEditDialog / ProviderEditDialog Select triggers
+ * must show mapped labels, not raw values.
+ *
+ * Prerequisites: `pnpm dev` with remote-debugging-port 9222.
+ * Usage: node scripts/cdp-issue-8-select-labels.mjs
+ */
+
+const CDP_BASE = process.env.ENSO_CDP_URL ?? 'http://127.0.0.1:9222';
+const ARTIFACT_DIR = process.env.ENSO_CDP_ARTIFACTS ?? '/opt/cursor/artifacts/screenshots';
+
+async function waitForCdp(timeoutMs = 60_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${CDP_BASE}/json/version`);
+      if (res.ok) return;
+    } catch {
+      // retry
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`CDP not reachable at ${CDP_BASE} after ${timeoutMs}ms`);
+}
+
+async function listTargets() {
+  const res = await fetch(`${CDP_BASE}/json/list`);
+  if (!res.ok) throw new Error(`json/list ${res.status}`);
+  return res.json();
+}
+
+async function waitForPage(predicate, timeoutMs = 20_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const pages = (await listTargets()).filter((t) => t.type === 'page');
+    const hit = pages.find(predicate);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error('Timed out waiting for page target');
+}
+
+function connect(wsUrl) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    const pending = new Map();
+    let nextId = 1;
+    ws.addEventListener('message', (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.id != null && pending.has(msg.id)) {
+        const { resolve: ok, reject: fail } = pending.get(msg.id);
+        pending.delete(msg.id);
+        if (msg.error) fail(new Error(JSON.stringify(msg.error)));
+        else ok(msg.result);
+      }
+    });
+    ws.addEventListener('open', () => {
+      const send = (method, params = {}) => {
+        const id = nextId++;
+        return new Promise((ok, fail) => {
+          pending.set(id, { resolve: ok, reject: fail });
+          ws.send(JSON.stringify({ id, method, params }));
+        });
+      };
+      resolve({ ws, send });
+    });
+    ws.addEventListener('error', reject);
+  });
+}
+
+async function evalExpr(send, expression) {
+  const res = await send('Runtime.evaluate', {
+    expression,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  if (res.exceptionDetails) {
+    throw new Error(JSON.stringify(res.exceptionDetails, null, 2));
+  }
+  return res.result?.value;
+}
+
+async function screenshot(send, filename) {
+  const { mkdir } = await import('node:fs/promises');
+  const { join } = await import('node:path');
+  await mkdir(ARTIFACT_DIR, { recursive: true });
+  const { data } = await send('Page.captureScreenshot', { format: 'png' });
+  const dest = join(ARTIFACT_DIR, filename);
+  await import('node:fs/promises').then((fs) => fs.writeFile(dest, Buffer.from(data, 'base64')));
+  return dest;
+}
+
+async function main() {
+  await waitForCdp();
+  const mainTarget = await waitForPage(
+    (p) => p.url.includes('index.html') || p.url.endsWith('/') || p.url.includes(':5173/')
+  );
+  const main = await connect(mainTarget.webSocketDebuggerUrl);
+  await main.send('Runtime.enable');
+  await main.send('Page.enable');
+
+  await evalExpr(
+    main.send,
+    `(() => {
+      const settings = window.__stores?.settings;
+      if (!settings) throw new Error('window.__stores.settings missing');
+      return new Promise((resolve) => {
+        const finish = () => {
+          settings.setState({ onboarded: true, language: 'en' });
+          settings.getState().addMcpServers([{
+            id: 'cdp-issue-8-mcp',
+            name: 'Issue 8 MCP',
+            transport: 'http',
+            url: 'https://example.com/mcp',
+            source: 'Manual',
+            enabled: true,
+          }]);
+          settings.getState().addProviders([{
+            id: 'cdp-issue-8-provider',
+            name: 'Issue 8 Probe',
+            api: 'anthropic-messages',
+            apiKey: '',
+            baseUrl: '',
+            enabled: true,
+            models: [{ id: 'claude-sonnet-4', label: 'Claude Sonnet 4', enabled: true }],
+          }]);
+          resolve({
+            language: settings.getState().language,
+            mcp: settings.getState().mcpServers.map((s) => s.name),
+            providers: settings.getState().providers.map((p) => p.name),
+          });
+        };
+        if (settings.persist?.hasHydrated?.()) finish();
+        else settings.persist?.onFinishHydration?.(finish) ?? finish();
+      });
+    })()`
+  );
+
+  await evalExpr(main.send, `window.electronAPI.window.openSettings()`);
+  const settingsTarget = await waitForPage((p) => p.url.includes('settings.html'));
+  const settings = await connect(settingsTarget.webSocketDebuggerUrl);
+  await settings.send('Runtime.enable');
+  await settings.send('Page.enable');
+  await new Promise((r) => setTimeout(r, 800));
+
+  const clickNav = (label) =>
+    evalExpr(
+      settings.send,
+      `(() => {
+        const btn = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === ${JSON.stringify(label)});
+        if (!btn) throw new Error('nav not found: ${label}');
+        btn.click();
+        return btn.textContent.trim();
+      })()`
+    );
+
+  const openRowEdit = (rowName) =>
+    evalExpr(
+      settings.send,
+      `(() => {
+        const row = [...document.querySelectorAll('div.group')].find((el) =>
+          (el.textContent || '').includes(${JSON.stringify(rowName)})
+        );
+        if (!row) throw new Error('row not found: ${rowName}');
+        const edit = row.querySelector('button');
+        const buttons = [...row.querySelectorAll('button')];
+        const pencil = buttons.find((b) => b.querySelector('svg')) ?? buttons[1] ?? buttons[0];
+        if (!pencil) throw new Error('edit button missing for ${rowName}');
+        pencil.click();
+        return true;
+      })()`
+    );
+
+  const readDialogSelects = () =>
+    evalExpr(
+      settings.send,
+      `(() => {
+        const dialog = document.querySelector('[role="dialog"], [data-slot="dialog-content"]')
+          ?? document.querySelector('[data-slot="dialog"]')
+          ?? document.body;
+        const triggers = [...document.querySelectorAll('[data-slot="select-trigger"]')];
+        return triggers.map((el) => ({
+          text: (el.innerText || el.textContent || '').replace(/\\s+/g, ' ').trim(),
+          valueSlot: (el.querySelector('[data-slot="select-value"]')?.textContent || '').trim(),
+        }));
+      })()`
+    );
+
+  const closeDialog = () =>
+    evalExpr(
+      settings.send,
+      `(() => {
+        const cancel = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Cancel');
+        if (cancel) cancel.click();
+        return Boolean(cancel);
+      })()`
+    );
+
+  await clickNav('MCP Servers');
+  await new Promise((r) => setTimeout(r, 300));
+  await openRowEdit('Issue 8 MCP');
+  await new Promise((r) => setTimeout(r, 400));
+  const mcpSelects = await readDialogSelects();
+  const mcpShot = await screenshot(settings.send, 'issue-8-mcp-edit-dialog.png');
+
+  await closeDialog();
+  await new Promise((r) => setTimeout(r, 300));
+
+  await clickNav('Model Providers');
+  await new Promise((r) => setTimeout(r, 300));
+  await openRowEdit('Issue 8 Probe');
+  await new Promise((r) => setTimeout(r, 400));
+  const providerSelects = await readDialogSelects();
+  const providerShot = await screenshot(settings.send, 'issue-8-provider-edit-dialog.png');
+
+  const report = {
+    mcpSelects,
+    providerSelects,
+    screenshots: { mcpShot, providerShot },
+    assertions: {
+      mcpTransportIsHttp: mcpSelects.some((s) => s.valueSlot === 'http' || s.text.includes('http')),
+      apiTypeIsAnthropic: providerSelects.some((s) =>
+        (s.valueSlot === 'Anthropic' || s.text.includes('Anthropic')) &&
+        !s.valueSlot.includes('anthropic-messages')
+      ),
+      testModelIsFriendlyLabel: providerSelects.some((s) =>
+        (s.valueSlot === 'Claude Sonnet 4' || s.text.includes('Claude Sonnet 4')) &&
+        !s.valueSlot.includes('claude-sonnet-4')
+      ),
+    },
+  };
+
+  const failed = Object.entries(report.assertions).filter(([, ok]) => !ok);
+  console.log(JSON.stringify(report, null, 2));
+  main.ws.close();
+  settings.ws.close();
+  if (failed.length) {
+    throw new Error(`CDP assertions failed: ${failed.map(([k]) => k).join(', ')}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/renderer/components/settings/McpEditDialog.tsx
+++ b/src/renderer/components/settings/McpEditDialog.tsx
@@ -137,7 +137,11 @@ export function McpEditDialog({ server, onClose }: McpEditDialogProps) {
 
           <Field>
             <FieldLabel>{t('Transport')}</FieldLabel>
-            <Select value={transport} onValueChange={(v) => setTransport(v as McpTransport)}>
+            <Select
+              items={MCP_TRANSPORTS.map((kind) => ({ value: kind, label: kind }))}
+              value={transport}
+              onValueChange={(v) => setTransport(v as McpTransport)}
+            >
               <SelectTrigger className="w-full">
                 <SelectValue />
               </SelectTrigger>

--- a/src/renderer/components/settings/ProviderEditDialog.tsx
+++ b/src/renderer/components/settings/ProviderEditDialog.tsx
@@ -36,6 +36,7 @@ import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
 import { Z_INDEX } from '@/lib/z-index';
 import { useSettingsStore } from '@/stores/settings';
+import { API_KIND_LABELS } from './constants';
 
 interface ProviderEditDialogProps {
   /** 'new' 表示手动新建 */
@@ -187,14 +188,18 @@ export function ProviderEditDialog({ provider, onClose }: ProviderEditDialogProp
             <>
               <Field>
                 <FieldLabel>{t('API Type')}</FieldLabel>
-                <Select value={api} onValueChange={(v) => setApi(v as ModelProvider['api'])}>
+                <Select
+                  items={API_KIND_LABELS}
+                  value={api}
+                  onValueChange={(v) => setApi(v as ModelProvider['api'])}
+                >
                   <SelectTrigger className="w-full">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectPopup zIndex={Z_INDEX.DROPDOWN_IN_MODAL}>
                     {MODEL_API_KINDS.map((kind) => (
                       <SelectItem key={kind} value={kind}>
-                        {kind}
+                        {API_KIND_LABELS[kind]}
                       </SelectItem>
                     ))}
                   </SelectPopup>
@@ -382,14 +387,21 @@ export function ProviderEditDialog({ provider, onClose }: ProviderEditDialogProp
               </Button>
             )}
             {!isOauth && models.length > 0 && (
-              <Select value={testModel} onValueChange={(v) => setTestModel(v ?? '')}>
+              <Select
+                items={models.map((model) => ({
+                  value: model.id,
+                  label: model.label ?? model.id,
+                }))}
+                value={testModel}
+                onValueChange={(v) => setTestModel(v ?? '')}
+              >
                 <SelectTrigger className="h-8 w-36">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectPopup zIndex={Z_INDEX.DROPDOWN_IN_MODAL}>
                   {models.map((model) => (
                     <SelectItem key={model.id} value={model.id}>
-                      {model.id}
+                      {model.label ?? model.id}
                     </SelectItem>
                   ))}
                 </SelectPopup>

--- a/src/renderer/components/settings/ProvidersSettings.tsx
+++ b/src/renderer/components/settings/ProvidersSettings.tsx
@@ -1,5 +1,5 @@
 import { CUSTOM_VENDOR_ID, groupProviders } from '@shared/providerGroups';
-import type { ModelApiKind, ModelProvider, OauthProviderInfo } from '@shared/types';
+import type { ModelProvider, OauthProviderInfo } from '@shared/types';
 import {
   BadgeCheck,
   HardDriveDownload,
@@ -18,17 +18,10 @@ import { Switch } from '@/components/ui/switch';
 import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores/settings';
+import { API_KIND_LABELS } from './constants';
 import { LocalImportDialog } from './LocalImportDialog';
 import { OauthProvidersDialog } from './OauthProvidersDialog';
 import { ProviderEditDialog } from './ProviderEditDialog';
-
-const API_LABELS: Record<ModelApiKind, string> = {
-  'openai-completions': 'OpenAI Completions',
-  'openai-responses': 'OpenAI Responses',
-  'anthropic-messages': 'Anthropic',
-  'google-generative-ai': 'Gemini',
-  ollama: 'Ollama',
-};
 
 export function ProvidersSettings() {
   const { t } = useI18n();
@@ -189,7 +182,7 @@ export function ProvidersSettings() {
                               )
                             ) : (
                               <Badge variant="outline" className="shrink-0 text-[11px]">
-                                {API_LABELS[provider.api] ?? provider.api}
+                                {API_KIND_LABELS[provider.api] ?? provider.api}
                               </Badge>
                             )}
                             {provider.importedFrom && (

--- a/src/renderer/components/settings/constants.ts
+++ b/src/renderer/components/settings/constants.ts
@@ -1,3 +1,4 @@
+import type { ModelApiKind } from '@shared/types';
 import type { FontWeight } from '@/stores/settings';
 
 export type SettingsCategory =
@@ -10,6 +11,15 @@ export type SettingsCategory =
   | 'presets'
   | 'agents'
   | 'tools';
+
+/** API 协议取值 → 设置页展示名；列表徽章与编辑弹窗共用。 */
+export const API_KIND_LABELS: Record<ModelApiKind, string> = {
+  'openai-completions': 'OpenAI Completions',
+  'openai-responses': 'OpenAI Responses',
+  'anthropic-messages': 'Anthropic',
+  'google-generative-ai': 'Gemini',
+  ollama: 'Ollama',
+};
 
 export const fontWeightOptions: { value: FontWeight; label: string }[] = [
   { value: 'normal', label: 'Normal' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8

## 问题

`McpEditDialog` 与 `ProviderEditDialog` 的 Select 没传 `items`。Base UI 在 popup 关闭时读不到 `SelectItem` 文案，触发器会画出原始 value。PR #2 已用同一手法修了 `GeneralSettings` / `AppearanceSettings`，这两处是同类遗留。

## 改动

- `McpEditDialog` Transport：`items={MCP_TRANSPORTS.map(kind => ({ value: kind, label: kind }))}`（文案与列表徽章一致，就是 transport id）
- `ProviderEditDialog` API Type：`items={API_KIND_LABELS}`，触发器显示 `Anthropic` 而不是 `anthropic-messages`
- `ProviderEditDialog` 测试模型：`items` 用 `model.label ?? model.id`
- `API_KIND_LABELS` 抽到 `constants.ts`，与供应商列表徽章共用，避免两套文案
- `.trellis/spec/renderer/dialogs.md` 补了一句：弹窗 Select 必须传 `items`

无 MCP 功能改动，无 provider 逻辑改动。

Base：`feature/model-ui-and-status-line`（不针对 `dev`，避免把 PR #2 整包带过去）。

## CDP 验证

脚本：[`scripts/cdp-issue-8-select-labels.mjs`](scripts/cdp-issue-8-select-labels.mjs)

在 `pnpm dev`（CDP `127.0.0.1:9222`）下：打开设置 → 编辑 MCP / Provider 弹窗 → 读 `[data-slot="select-value"]`。

| 触发器 | 原始 value | 实测文案 |
|---|---|---|
| MCP Transport | `http` | `http`（与 item label 相同） |
| Provider API Type | `anthropic-messages` | **Anthropic** |
| Provider 测试模型 | `claude-sonnet-4` | **Claude Sonnet 4** |

`npx tsc --noEmit` → 0。未 merge。

[MCP edit dialog Transport trigger](https://cursor.com/agents/bc-8f10222c-8001-4fba-95af-eae5437a2500/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fissue-8-mcp-edit-dialog.png)
[Provider edit dialog API Type and test-model triggers](https://cursor.com/agents/bc-8f10222c-8001-4fba-95af-eae5437a2500/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fissue-8-provider-edit-dialog.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f10222c-8001-4fba-95af-eae5437a2500?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f10222c-8001-4fba-95af-eae5437a2500&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

