### PR TITLE
chore(tooling): ignore .hce in biome.json (#9)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -60,6 +60,7 @@
       "!.cursor",
       "!.omp",
       "!.pi",
+      "!.hce",
       "!temp"
     ]
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #9.

`.hce` is a local code-search index. It was only excluded via `.git/info/exclude`, so a fresh clone still failed `biome check .` on `.hce/config.json` and `.hce/index.json`.

This PR adds one line — `!.hce` — to `files.includes` in `biome.json`, same style as the other tool-output folders (`.trellis`, `.agents`, `.cursor`, `.omp`, `.pi`). No other files.

**This replaces the polluted retarget of PR #14.** #14 was opened against `dev` (and later retargeted in a polluted way). This is a clean one-line change from the current tip of `feature/model-ui-and-status-line` (`9e29b44`).

## Verification

- `biome.json` is valid JSON.
- `pnpm exec biome check .` — no `.hce` diagnostics. Remaining 7 errors / 3 warnings / 2 infos are pre-existing on the feature branch (format/lint in app files, plus the `recommended` deprecation info). This PR does not touch those files.
- Temporary `.hce/config.json` and `.hce/index.json` were created to reproduce #9: Biome reports “These paths were provided but ignored”.

Do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ede8404-e413-451a-8668-f0e9d3ec3d5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ede8404-e413-451a-8668-f0e9d3ec3d5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

