### PR TITLE
fix(i18n): 模块级常量硬编码文案随 locale 切换

### DIFF
--- a/.trellis/spec/renderer/i18n.md
+++ b/.trellis/spec/renderer/i18n.md
@@ -46,9 +46,16 @@ const { t } = useI18n();
 切换语言会同时设置 `document.documentElement.lang`（在 `applySettings` 里），
 新增语言相关副作用要写在那里才能多窗口同步。
 
+## 模块级常量
+
+模块顶层不能调 `useI18n()`。用户可见文案要进常量时，存英文 key（或 `LABEL_KEYS` 映射），由组件消费侧 `t()`。不要在模块作用域写 `t()`——locale 那时还没定，切语言也不会更新。
+
+例：`BUILTIN_TOOLS[].description`、`ALERT_STYLES.label`、`GeneralSettings.ACTION_LABEL_KEYS`。
+
 ## 不要做的事
 
 - 不要在主进程里翻译。主进程返回**原始英文错误信息**或结构化错误码，
   由渲染层决定怎么呈现（见 `providerApi.ts` 的 `toMessage`）。
 - 主进程里少数面向用户的展示名（如 `SOURCE_NAMES` 的 `'Claude Code 插件'`）
   是数据不是文案，直接写中文即可，不走 i18n。
+- 不要把中文字面量写进模块级用户可见常量再在英文界面直接渲染。

--- a/src/renderer/components/chat/Markdown.tsx
+++ b/src/renderer/components/chat/Markdown.tsx
@@ -2,6 +2,7 @@ import type { Root } from 'mdast';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { visit } from 'unist-util-visit';
+import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
 import { CodeBlock } from './CodeBlock';
 import { CopyButton } from './CopyButton';
@@ -61,6 +62,7 @@ const FILE_PATH_RE =
 
 /** assistant 正文的 markdown 渲染，样式内联为 Tailwind（项目未引入 typography 插件） */
 export function Markdown({ text, streaming = false }: { text: string; streaming?: boolean }) {
+  const { t } = useI18n();
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkGithubAlerts]}
@@ -89,7 +91,7 @@ export function Markdown({ text, streaming = false }: { text: string; streaming?
             return (
               <blockquote className={cn('my-1.5 border-l-2 pl-3', alert.border)}>
                 <p className={cn('mt-1.5 mb-0.5 text-xs font-semibold', alert.text)}>
-                  {alert.label}
+                  {t(alert.label)}
                 </p>
                 {children}
               </blockquote>

--- a/src/renderer/components/chat/Markdown.tsx
+++ b/src/renderer/components/chat/Markdown.tsx
@@ -48,9 +48,14 @@ function remarkGithubAlerts() {
       text.value = text.value.slice(match[0].length);
       // 标记后正文为空时去掉空 text 节点
       if (!text.value) first.children.shift();
+      const kind = match[1].toLowerCase();
       node.data = {
         ...node.data,
-        hProperties: { ...node.data?.hProperties, 'data-alert': match[1].toLowerCase() },
+        hProperties: {
+          ...node.data?.hProperties,
+          'data-alert': kind,
+          dataAlert: kind,
+        },
       };
     });
   };
@@ -86,7 +91,9 @@ export function Markdown({ text, streaming = false }: { text: string; streaming?
         h2: ({ children }) => <h2 className="mt-3 mb-1.5 text-base font-semibold">{children}</h2>,
         h3: ({ children }) => <h3 className="mt-2 mb-1 text-sm font-semibold">{children}</h3>,
         blockquote: ({ children, node }) => {
-          const alert = ALERT_STYLES[String(node?.properties?.dataAlert ?? '')];
+          const props = node?.properties as Record<string, unknown> | undefined;
+          const kind = String(props?.dataAlert ?? props?.['data-alert'] ?? '');
+          const alert = ALERT_STYLES[kind];
           if (alert) {
             return (
               <blockquote className={cn('my-1.5 border-l-2 pl-3', alert.border)}>

--- a/src/renderer/components/chat/TimelineRow.tsx
+++ b/src/renderer/components/chat/TimelineRow.tsx
@@ -465,6 +465,7 @@ function ThinkingRow({
 
 /** 后台任务完成事件：分隔线嵌字；点击展开详情与完整日志 */
 function TaskNoteRow({ item }: { item: Extract<TimelineItem, { kind: 'task-note' }> }) {
+  const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
   const [log, setLog] = useState<string | null>(null);
   const match = /^Background task (\S+) finished \((.+?), ran (.+?)\)/.exec(item.summary);
@@ -474,9 +475,9 @@ function TaskNoteRow({ item }: { item: Extract<TimelineItem, { kind: 'task-note'
   useEffect(() => {
     if (!expanded || !logPath || log !== null) return;
     void window.electronAPI.files.read(logPath).then((content) => {
-      setLog(content ?? '(log unavailable)');
+      setLog(content ?? t('(log unavailable)'));
     });
-  }, [expanded, logPath, log]);
+  }, [expanded, logPath, log, t]);
 
   return (
     <div>
@@ -500,7 +501,7 @@ function TaskNoteRow({ item }: { item: Extract<TimelineItem, { kind: 'task-note'
             {item.detail}
           </pre>
           <pre className="max-h-64 overflow-auto px-3 py-2 font-mono text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground">
-            {logPath ? (log ?? 'Loading…') : '(no log available)'}
+            {logPath ? (log ?? t('Loading…')) : t('(no log available)')}
           </pre>
         </div>
       )}

--- a/src/renderer/components/chat/TimelineRow.tsx
+++ b/src/renderer/components/chat/TimelineRow.tsx
@@ -467,17 +467,18 @@ function ThinkingRow({
 function TaskNoteRow({ item }: { item: Extract<TimelineItem, { kind: 'task-note' }> }) {
   const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
-  const [log, setLog] = useState<string | null>(null);
+  /** undefined=未读, null=文件不存在, string=内容。占位文案在渲染时 t()，切语言才会更新 */
+  const [log, setLog] = useState<string | null | undefined>(undefined);
   const match = /^Background task (\S+) finished \((.+?), ran (.+?)\)/.exec(item.summary);
   const text = match ? `${match[1]} · ${match[2]} · ${match[3]}` : item.summary;
   const logPath = /read (\/.+?\.log) for the complete log/.exec(item.detail)?.[1] ?? null;
 
   useEffect(() => {
-    if (!expanded || !logPath || log !== null) return;
+    if (!expanded || !logPath || log !== undefined) return;
     void window.electronAPI.files.read(logPath).then((content) => {
-      setLog(content ?? t('(log unavailable)'));
+      setLog(content);
     });
-  }, [expanded, logPath, log, t]);
+  }, [expanded, logPath, log]);
 
   return (
     <div>
@@ -501,7 +502,11 @@ function TaskNoteRow({ item }: { item: Extract<TimelineItem, { kind: 'task-note'
             {item.detail}
           </pre>
           <pre className="max-h-64 overflow-auto px-3 py-2 font-mono text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground">
-            {logPath ? (log ?? t('Loading…')) : t('(no log available)')}
+            {logPath
+              ? log === undefined
+                ? t('Loading…')
+                : (log ?? t('(log unavailable)'))
+              : t('(no log available)')}
           </pre>
         </div>
       )}

--- a/src/renderer/components/settings/BuiltinToolsSettings.tsx
+++ b/src/renderer/components/settings/BuiltinToolsSettings.tsx
@@ -24,7 +24,7 @@ export function BuiltinToolsSettings() {
             <Wrench className="h-4 w-4 shrink-0 text-muted-foreground" />
             <div className="min-w-0 flex-1">
               <p className="text-sm font-medium">{tool.name}</p>
-              <p className="text-muted-foreground text-xs">{tool.description}</p>
+              <p className="text-muted-foreground text-xs">{t(tool.description)}</p>
             </div>
             <Switch
               checked={!disabled.includes(tool.id)}

--- a/src/shared/i18n.test.ts
+++ b/src/shared/i18n.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getTranslation, normalizeLocale, translate, zhTranslations } from './i18n';
+import { BUILTIN_TOOLS } from './types/builtinTools';
 
 /** 间接映射表里的 t() key。删孤儿时漏看这些会把正在用的词条删掉。 */
 const MAPPED_I18N_KEYS = [
@@ -107,5 +108,27 @@ describe('translate', () => {
 
   it('数字参数正确转成字符串', () => {
     expect(translate('zh', 'Connected ({{ms}}ms)', { ms: 128 })).toBe('连接成功(128ms)');
+  });
+});
+
+describe('模块级常量的 i18n key（#5）', () => {
+  const alertLabels = ['Note', 'Tip', 'Important', 'Warning', 'Caution'] as const;
+  const taskNoteKeys = ['(log unavailable)', 'Loading…', '(no log available)'] as const;
+
+  it('内置工具说明存英文 key，中文表有对应译文', () => {
+    for (const tool of BUILTIN_TOOLS) {
+      expect(tool.description).not.toMatch(/[\u4e00-\u9fff]/);
+      expect(zhTranslations[tool.description]).toBeDefined();
+      expect(translate('en', tool.description)).toBe(tool.description);
+      expect(translate('zh', tool.description)).not.toBe(tool.description);
+    }
+  });
+
+  it('GitHub alert 标题与 task-note 占位文案两边 locale 都能解析', () => {
+    for (const key of [...alertLabels, ...taskNoteKeys]) {
+      expect(translate('en', key)).toBe(key);
+      expect(zhTranslations[key]).toBeDefined();
+      expect(translate('zh', key)).toBe(zhTranslations[key]);
+    }
   });
 });

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -225,6 +225,23 @@ export const zhTranslations: Record<string, string> = {
   'Built-in tools': '内置工具',
   'Toggle the built-in tools available to agents. All enabled by default.':
     '开关 agent 可用的内置工具,默认全部启用。',
+  'One-shot subagent: delegate a self-contained task and return a final report (parallel or async)':
+    '一次性子代理:委派自包含子任务,返回最终报告(可并行、可异步)',
+  'Persistent subagent: hire for multi-turn dialogue; you can watch and intervene from a tab':
+    '持久子代理:雇佣后多轮对话,用户可在 tab 旁观介入',
+  'Task list: track progress on multi-step work': '任务清单:跟踪多步骤工作的进度',
+  'Ask the user a question and wait for an answer (options / timeout)':
+    '向用户提问并等待回答(带选项/超时)',
+  'Background shell task: run long commands in the background and notify on completion':
+    '后台 shell 任务:长命令挂后台跑,完成时通知',
+  '(log unavailable)': '(日志不可用)',
+  'Loading…': '加载中…',
+  '(no log available)': '(暂无日志)',
+  Note: '注意',
+  Tip: '提示',
+  Important: '重要',
+  Warning: '警告',
+  Caution: '小心',
   'Custom subagent presets: system prompt, model and toolset. The agent picks one via the agent_type parameter.':
     '自定义子代理预设:系统提示、模型与工具集,主 agent 经 agent_type 参数选用。',
   'New agent type': '新建类型',

--- a/src/shared/types/builtinTools.ts
+++ b/src/shared/types/builtinTools.ts
@@ -3,6 +3,7 @@ export interface BuiltinToolInfo {
   /** 稳定 id,用于开关持久化与下发过滤 */
   id: string;
   name: string;
+  /** i18n key（英文原文）；模块级不能调 hook，设置页消费侧 t() */
   description: string;
 }
 
@@ -10,18 +11,25 @@ export const BUILTIN_TOOLS: BuiltinToolInfo[] = [
   {
     id: 'subagent',
     name: 'Subagent',
-    description: '一次性子代理:委派自包含子任务,返回最终报告(可并行、可异步)',
+    description:
+      'One-shot subagent: delegate a self-contained task and return a final report (parallel or async)',
   },
   {
     id: 'coworker',
     name: 'Coworker',
-    description: '持久子代理:雇佣后多轮对话,用户可在 tab 旁观介入',
+    description:
+      'Persistent subagent: hire for multi-turn dialogue; you can watch and intervene from a tab',
   },
-  { id: 'todo', name: 'Todo', description: '任务清单:跟踪多步骤工作的进度' },
-  { id: 'ask_user', name: 'Ask user', description: '向用户提问并等待回答(带选项/超时)' },
+  { id: 'todo', name: 'Todo', description: 'Task list: track progress on multi-step work' },
+  {
+    id: 'ask_user',
+    name: 'Ask user',
+    description: 'Ask the user a question and wait for an answer (options / timeout)',
+  },
   {
     id: 'background_tasks',
     name: 'Background tasks',
-    description: '后台 shell 任务:长命令挂后台跑,完成时通知',
+    description:
+      'Background shell task: run long commands in the background and notify on completion',
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #5

## 问题

模块级常量里的用户可见文案不能调 hook，英文界面会泄露中文（或固定英文不随 locale 变）。

## 做法

存英文 key，由消费侧 `t()`：

- `BUILTIN_TOOLS[].description` → `BuiltinToolsSettings` 里 `t(tool.description)`
- `ALERT_STYLES.label` → `Markdown` 渲染时 `t(alert.label)`
- `TaskNoteRow` 的 `(log unavailable)` / `Loading…` / `(no log available)` 渲染时 `t()`
- 对应中文写进 `src/shared/i18n.ts`（中文工具说明沿用原来的五条字面量）

未翻译（按 issue 例外）：语言自称名、品牌 `EnsoCode`、`API_LABELS`、用户自定义供应商名。未做孤儿词条清理（#3）。

附带两处才能让消费侧 `t()` 真的跑起来：

- `data-alert` 从 remark 传到 blockquote 的 `node.properties`（否则 GitHub alert 标题根本不渲染）
- 日志内容与「不可用」分离，占位文案在渲染时 `t()`，切语言才会更新

## CDP

`pnpm dev` + 9222。设置页内置工具、对话时间线（Markdown alert + 展开的 task-note），中英各走一遍。

| 检查 | en | zh |
|---|---|---|
| 内置工具说明 | 英文，无中文泄露 | 原中文，无英文 key |
| Alert 标题 | Note / Tip / Important / Warning / Caution | 注意 / 提示 / 重要 / 警告 / 小心 |
| task-note | `(no log available)` / `(log unavailable)` | `(暂无日志)` / `(日志不可用)` |

**English — Built-in tools**
[English built-in tools](https://cursor.com/agents/bc-227bc8eb-5a64-4df3-89f3-4817cdfaaf1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fissue-5-tools-en.png)

**简体中文 — 内置工具**
[Chinese built-in tools](https://cursor.com/agents/bc-227bc8eb-5a64-4df3-89f3-4817cdfaaf1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fissue-5-tools-zh.png)

**English — timeline alerts + task-note**
[English timeline](https://cursor.com/agents/bc-227bc8eb-5a64-4df3-89f3-4817cdfaaf1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fissue-5-timeline-en.png)

**简体中文 — 时间线 alert + task-note**
[Chinese timeline](https://cursor.com/agents/bc-227bc8eb-5a64-4df3-89f3-4817cdfaaf1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fissue-5-timeline-zh.png)

Base is `feature/model-ui-and-status-line`（不要带整棵 feature 合进 `dev`）。不合并，等 review。


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-227bc8eb-5a64-4df3-89f3-4817cdfaaf1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-227bc8eb-5a64-4df3-89f3-4817cdfaaf1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

