### PR TITLE
fix(agent): resolve custom model reasoning via catalog then row overrides (#6)

### DIFF
--- a/src/agent/supervisor.resolve.test.ts
+++ b/src/agent/supervisor.resolve.test.ts
@@ -1,0 +1,160 @@
+import type { ModelRuntime } from '@earendil-works/pi-coding-agent';
+import { describe, expect, it, vi } from 'vitest';
+import { resolveBaseModel } from './supervisor';
+
+vi.mock('@shared/piAccounts', () => ({
+  ensureAccountProvider: vi.fn(),
+}));
+
+type CatalogRow = {
+  id: string;
+  reasoning?: boolean;
+  thinkingLevelMap?: Record<string, string | null | undefined>;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+function mockRuntime(options: {
+  catalog?: CatalogRow[];
+  oauthModel?: CatalogRow & { provider?: string };
+}): ModelRuntime {
+  const registered = new Map<string, CatalogRow>();
+  const catalog = options.catalog ?? [];
+  return {
+    getModels: () => catalog,
+    getModel: (providerId: string, modelId: string) => {
+      if (options.oauthModel && providerId === 'anthropic' && modelId === options.oauthModel.id) {
+        return options.oauthModel;
+      }
+      return registered.get(`${providerId}:${modelId}`);
+    },
+    registerProvider: (providerId: string, config: { models: CatalogRow[] }) => {
+      for (const model of config.models) {
+        registered.set(`${providerId}:${model.id}`, model);
+      }
+    },
+  } as unknown as ModelRuntime;
+}
+
+const apiKeySpawn = {
+  api: 'anthropic-messages' as const,
+  baseUrl: 'https://relay.example/v1',
+  apiKey: 'sk-relay',
+  modelId: 'claude-sonnet-4',
+};
+
+describe('resolveBaseModel apiKey', () => {
+  it('catalog 命中官方 id 时用 catalog，不再无条件 {max:max}', () => {
+    const runtime = mockRuntime({
+      catalog: [
+        {
+          id: 'claude-sonnet-4',
+          reasoning: true,
+          contextWindow: 200_000,
+          maxTokens: 64_000,
+        },
+      ],
+    });
+    const model = resolveBaseModel(runtime, apiKeySpawn);
+    expect(model.reasoning).toBe(true);
+    expect(model.thinkingLevelMap).toBeUndefined();
+    expect(model.contextWindow).toBe(200_000);
+    expect(model.maxTokens).toBe(64_000);
+  });
+
+  it('catalog 未命中保持乐观默认', () => {
+    const runtime = mockRuntime({ catalog: [] });
+    const model = resolveBaseModel(runtime, {
+      ...apiKeySpawn,
+      modelId: 'my-private-gateway-model',
+    });
+    expect(model.reasoning).toBe(true);
+    expect(model.thinkingLevelMap).toEqual({ max: 'max' });
+    expect(model.contextWindow).toBe(128_000);
+    expect(model.maxTokens).toBe(32_000);
+  });
+
+  it('行覆盖压过 catalog', () => {
+    const runtime = mockRuntime({
+      catalog: [
+        {
+          id: 'claude-sonnet-4',
+          reasoning: true,
+          thinkingLevelMap: { max: 'max' },
+          contextWindow: 200_000,
+          maxTokens: 64_000,
+        },
+      ],
+    });
+    const model = resolveBaseModel(runtime, {
+      ...apiKeySpawn,
+      reasoning: 'off',
+      thinkingLevel: 'low',
+      contextWindow: 80_000,
+      maxTokens: 8_000,
+    });
+    expect(model.reasoning).toBe(false);
+    expect(model.thinkingLevelMap).toBeUndefined();
+    expect(model.contextWindow).toBe(80_000);
+    expect(model.maxTokens).toBe(8_000);
+  });
+
+  it('空覆盖跟随 catalog', () => {
+    const runtime = mockRuntime({
+      catalog: [
+        {
+          id: 'gpt-4.1',
+          reasoning: false,
+          contextWindow: 1_047_576,
+          maxTokens: 32_768,
+        },
+      ],
+    });
+    const model = resolveBaseModel(runtime, {
+      api: 'openai-completions',
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-test',
+      modelId: 'gpt-4.1',
+    });
+    expect(model.reasoning).toBe(false);
+    expect(model.thinkingLevelMap).toBeUndefined();
+    expect(model.contextWindow).toBe(1_047_576);
+  });
+});
+
+describe('resolveBaseModel oauth', () => {
+  it('订阅路径仍直取 catalog，忽略行覆盖字段', () => {
+    const oauthModel = {
+      id: 'claude-sonnet-4-5',
+      reasoning: true,
+      thinkingLevelMap: { max: 'max' },
+      contextWindow: 200_000,
+      maxTokens: 64_000,
+      provider: 'anthropic',
+    };
+    const registerProvider = vi.fn();
+    const runtime = {
+      getModels: vi.fn(() => {
+        throw new Error('oauth 不应走全局 catalog 反查');
+      }),
+      getModel: vi.fn(() => oauthModel),
+      registerProvider,
+    } as unknown as ModelRuntime;
+
+    const resolved = resolveBaseModel(runtime, {
+      api: 'anthropic-messages',
+      baseUrl: '',
+      apiKey: '',
+      modelId: 'claude-sonnet-4-5',
+      oauthAccountKey: 'anthropic',
+      reasoning: 'off',
+      thinkingLevel: 'low',
+      contextWindow: 1,
+      maxTokens: 1,
+    });
+
+    expect(resolved).toBe(oauthModel);
+    expect(runtime.getModel).toHaveBeenCalledWith('anthropic', 'claude-sonnet-4-5');
+    expect(registerProvider).not.toHaveBeenCalled();
+  });
+});

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -14,6 +14,11 @@ import {
   ModelRuntime,
   SessionManager,
 } from '@earendil-works/pi-coding-agent';
+import {
+  findCatalogModelById,
+  positiveContextWindow,
+  resolveCustomModelCapabilities,
+} from '@shared/modelCatalog';
 import { ensureAccountProvider } from '@shared/piAccounts';
 import { ANTIGRAVITY_PROVIDER_ID, antigravityProviderConfig } from '@shared/providers/antigravity';
 import type {
@@ -473,7 +478,7 @@ export class SessionSupervisor {
     if (this.sessions.has(sessionId)) return;
     const spawnStart = Date.now();
     const runtime = await this.getRuntime();
-    // 注册基础模型恒 reasoning:true（放开全部档位能力）。开关/adaptive 由 per-session
+    // 基础模型按行覆盖 > catalog > 乐观默认注册。开关/adaptive 由 per-session
     // 克隆的 applyReasoningToModel 决定，避免同 provider 多会话共享引用而串台或被后开会话覆盖。
     const baseModel = resolveBaseModel(runtime, model);
     // per-session 独立副本：set-reasoning 就地改它，不污染其它会话
@@ -1343,11 +1348,6 @@ function consumeRole(managed: { pendingRole?: string }, text: string): string {
   return `<role>\n${role}\n</role>\n\n${text}`;
 }
 
-function positiveContextWindow(model: { contextWindow?: number } | undefined): number | undefined {
-  const value = model?.contextWindow;
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
-}
-
 const slugify = (value: string): string =>
   value
     .toLowerCase()
@@ -1367,10 +1367,10 @@ function providerKeyFor(model: { api: string; baseUrl: string; apiKey: string })
 
 /**
  * 解析 spawn 模型：oauth 直取 pi 内置 catalog（凭证由 runtime 从共享 auth.json 解析，
- * 不注册自定义 provider、不覆盖 UA——订阅端点保持 pi 原生标识）；
- * apiKey 注册自定义 provider（恒 reasoning:true，档位由 per-session 克隆决定）。
+ * 不注册自定义 provider、不覆盖 UA、不读行覆盖——订阅端点保持 pi 原生标识）；
+ * apiKey 注册自定义 provider：行覆盖 > 精确 catalog id > 乐观默认。
  */
-function resolveBaseModel(runtime: ModelRuntime, model: SpawnModelConfig) {
+export function resolveBaseModel(runtime: ModelRuntime, model: SpawnModelConfig) {
   if (model.oauthAccountKey) {
     // worker 与 Main 是两个 ModelRuntime 实例，只共用 auth.json。合成 id（第 2+ 个账号）
     // 的克隆 provider 必须在本进程也注册一遍，否则 getModel 取不到
@@ -1382,14 +1382,10 @@ function resolveBaseModel(runtime: ModelRuntime, model: SpawnModelConfig) {
     return oauthModel;
   }
   const providerId = providerKeyFor(model);
-  const catalog = runtime.getModels().find((entry) => entry.id === model.modelId);
-  const contextWindow = positiveContextWindow(catalog) ?? 128_000;
-  const maxTokens =
-    typeof catalog?.maxTokens === 'number' &&
-    Number.isFinite(catalog.maxTokens) &&
-    catalog.maxTokens > 0
-      ? Math.floor(catalog.maxTokens)
-      : 32_000;
+  const catalog = findCatalogModelById(runtime.getModels(), model.modelId);
+  const resolved = resolveCustomModelCapabilities(catalog, model);
+  const contextWindow = resolved.contextWindow ?? 128_000;
+  const maxTokens = resolved.maxTokens ?? 32_000;
   runtime.registerProvider(providerId, {
     baseUrl: model.baseUrl,
     api: model.api,
@@ -1400,9 +1396,8 @@ function resolveBaseModel(runtime: ModelRuntime, model: SpawnModelConfig) {
       {
         id: model.modelId,
         name: model.modelId,
-        reasoning: true,
-        // max 档需显式声明，否则被钳到 high
-        thinkingLevelMap: { max: 'max' },
+        reasoning: resolved.reasoning,
+        ...(resolved.thinkingLevelMap ? { thinkingLevelMap: resolved.thinkingLevelMap } : {}),
         input: ['text', 'image'],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         // applyExtension 原样展开定义，不填默认值；缺 contextWindow 时 pi 会把 max_tokens 钳成 NaN

--- a/src/main/services/agentHost.ts
+++ b/src/main/services/agentHost.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { pickModelCapabilityOverrides } from '@shared/modelCatalog';
 import {
   type AgentCommand,
   type AgentSpawnRequest,
@@ -14,7 +15,7 @@ import {
   type ThinkingLevel,
 } from '@shared/types/agent';
 import { BUILTIN_AGENT_TYPES, DEFAULT_PRESET_ID, type Preset } from '@shared/types/assets';
-import type { ModelProvider } from '@shared/types/llm';
+import type { ModelEntry, ModelProvider } from '@shared/types/llm';
 import { app, type UtilityProcess, utilityProcess } from 'electron';
 import { readSettings } from '../ipc/settings';
 import { resolveGlobalInstruction } from './instructionStore';
@@ -84,13 +85,7 @@ export function spawnSession(request: AgentSpawnRequest): { ok: boolean; error?:
   const instruction = resolveGlobalInstruction(
     preset ? { instructionId: preset.instructionId } : undefined
   );
-  const model: SpawnModelConfig = {
-    api: provider.api,
-    baseUrl: provider.baseUrl,
-    apiKey: provider.apiKey,
-    modelId: request.modelId,
-    ...(provider.oauthAccountKey ? { oauthAccountKey: provider.oauthAccountKey } : {}),
-  };
+  const model = spawnModelConfig(provider, request.modelId);
   return sendCommand({
     type: 'spawn',
     sessionId: request.sessionId,
@@ -183,17 +178,7 @@ function configuredAgentTypes(): AgentTypeSpawnConfig[] {
     .map((entry) => {
       const provider = entry.providerId ? findProvider(entry.providerId) : null;
       const model =
-        provider && entry.modelId
-          ? {
-              api: provider.api,
-              baseUrl: provider.baseUrl,
-              apiKey: provider.apiKey,
-              modelId: entry.modelId,
-              // 订阅条目的凭证在 auth.json 里，不透传这个 key 的话 worker 侧
-              // 会当成「空 apiKey 的自定义 provider」注册，subagent 绑订阅模型直接失效
-              ...(provider.oauthAccountKey ? { oauthAccountKey: provider.oauthAccountKey } : {}),
-            }
-          : undefined;
+        provider && entry.modelId ? spawnModelConfig(provider, entry.modelId) : undefined;
       return {
         name: String(entry.name),
         description: String(entry.description ?? ''),
@@ -382,4 +367,17 @@ function findProvider(providerId: string): ModelProvider | null {
   const state = readSettingsState();
   const providers = Array.isArray(state?.providers) ? (state.providers as ModelProvider[]) : [];
   return providers.find((provider) => provider?.id === providerId) ?? null;
+}
+
+/** oauth 只走 catalog；apiKey 才把行覆盖带进 spawn。 */
+function spawnModelConfig(provider: ModelProvider, modelId: string): SpawnModelConfig {
+  const entry = provider.models.find((model: ModelEntry) => model.id === modelId);
+  return {
+    api: provider.api,
+    baseUrl: provider.baseUrl,
+    apiKey: provider.apiKey,
+    modelId,
+    ...(provider.oauthAccountKey ? { oauthAccountKey: provider.oauthAccountKey } : {}),
+    ...(!provider.oauthAccountKey ? pickModelCapabilityOverrides(entry) : {}),
+  };
 }

--- a/src/main/services/modelMeta.test.ts
+++ b/src/main/services/modelMeta.test.ts
@@ -53,14 +53,19 @@ describe('queryModelMeta', () => {
     expect(Array.isArray(meta.thinkingLevels)).toBe(true);
   });
 
-  it('API-key 反查命中时不带 reasoning / thinkingLevels', async () => {
+  it('API-key 反查命中时带 catalog 的 reasoning / thinkingLevels（与 spawn 同表）', async () => {
     const { queryModelMeta } = await import('./modelMeta');
+    const { getRuntime } = await import('./oauthProviders');
+    const runtime = await getRuntime();
+    const catalog = runtime.getModels().find((entry) => entry.id === 'claude-sonnet-4-5');
+    expect(catalog).toBeDefined();
+
     const result = await queryModelMeta({ modelIds: ['claude-sonnet-4-5'] });
     expect(result.ok).toBe(true);
     expect(result.models[0]?.source).toBe('catalog-fallback');
-    expect(result.models[0]).not.toHaveProperty('reasoning');
-    expect(result.models[0]).not.toHaveProperty('thinkingLevels');
-    expect(result.models[0]?.contextWindow).toBeGreaterThan(0);
+    expect(result.models[0]?.reasoning).toBe(catalog?.reasoning);
+    expect(Array.isArray(result.models[0]?.thinkingLevels)).toBe(true);
+    expect(result.models[0]?.contextWindow).toBe(catalog?.contextWindow);
   });
 
   it('catalog 未命中时 source=unknown，可选字段缺失', async () => {

--- a/src/main/services/modelMeta.ts
+++ b/src/main/services/modelMeta.ts
@@ -1,47 +1,46 @@
+import {
+  type CatalogModelEntry,
+  findCatalogModelById,
+  positiveFiniteNumber,
+} from '@shared/modelCatalog';
 import { supportedProjectThinkingLevels } from '@shared/modelThinking';
 import { ensureAccountProvider } from '@shared/piAccounts';
 import type { ModelMeta, ModelMetaQuery, ModelMetaResult } from '@shared/types';
 import { ensureProviderModelsRefreshed, getRuntime, hasStoredAccount } from './oauthProviders';
 
-type CatalogEntry = {
-  id: string;
-  contextWindow?: number;
-  maxTokens?: number;
-  reasoning: boolean;
-  thinkingLevelMap?: Record<string, string | null | undefined>;
-};
-
-/**
- * 与 `supervisor.ts` 的 `positiveContextWindow` 同口径：非正 / 非有限视为缺失。
- * 未知不得用 128K 凑数——那是 spawn 的运行时兜底，不是元数据。
- */
-function positiveNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
-}
-
-function attachWindow(meta: ModelMeta, model: CatalogEntry): void {
-  const contextWindow = positiveNumber(model.contextWindow);
+function attachWindow(meta: ModelMeta, model: CatalogModelEntry): void {
+  const contextWindow = positiveFiniteNumber(model.contextWindow);
   if (contextWindow !== undefined) meta.contextWindow = contextWindow;
-  const maxTokens = positiveNumber(model.maxTokens);
+  const maxTokens = positiveFiniteNumber(model.maxTokens);
   if (maxTokens !== undefined) meta.maxTokens = maxTokens;
 }
 
-function mapOauthModel(model: CatalogEntry): ModelMeta {
+function mapOauthModel(model: CatalogModelEntry): ModelMeta {
   const meta: ModelMeta = {
     modelId: model.id,
     reasoning: model.reasoning,
-    thinkingLevels: supportedProjectThinkingLevels(model),
+    thinkingLevels: supportedProjectThinkingLevels({
+      reasoning: model.reasoning === true,
+      thinkingLevelMap: model.thinkingLevelMap,
+    }),
     source: 'catalog',
   };
   attachWindow(meta, model);
   return meta;
 }
 
-function mapCatalogFallback(modelId: string, catalog: CatalogEntry | undefined): ModelMeta {
+function mapCatalogFallback(modelId: string, catalog: CatalogModelEntry | undefined): ModelMeta {
   if (!catalog) return { modelId, source: 'unknown' };
-  // 自定义 API 命中 catalog 只借窗口；reasoning / thinkingLevels 留给「未知」——
-  // spawn 走的是硬编码 reasoning:true + {max:'max'}，报 catalog 档会和线上不一致。
+  // 与 spawn 同表精确 id 反查：命中则带上 catalog 的 reasoning / 档位 / 窗口。
+  // 行覆盖由 renderer 用 resolveCustomModelCapabilities 叠，不在这条查询里算。
   const meta: ModelMeta = { modelId, source: 'catalog-fallback' };
+  if (typeof catalog.reasoning === 'boolean') {
+    meta.reasoning = catalog.reasoning;
+    meta.thinkingLevels = supportedProjectThinkingLevels({
+      reasoning: catalog.reasoning,
+      thinkingLevelMap: catalog.thinkingLevelMap,
+    });
+  }
   attachWindow(meta, catalog);
   return meta;
 }
@@ -64,7 +63,7 @@ export async function queryModelMeta(query: ModelMetaQuery): Promise<ModelMetaRe
       // getRuntime 在后台预热扩展 catalog；这里 await 同一份 promise，保证冷启动首查
       // 不会抢先把 unknown 写进 renderer 的无 TTL 缓存。
       await ensureProviderModelsRefreshed(runtime, query.oauthAccountKey);
-      const catalog = runtime.getModels(query.oauthAccountKey) as readonly CatalogEntry[];
+      const catalog = runtime.getModels(query.oauthAccountKey) as readonly CatalogModelEntry[];
       const wanted = query.modelIds.length === 0 ? null : new Set(query.modelIds);
       const models: ModelMeta[] = [];
       const seen = new Set<string>();
@@ -86,14 +85,11 @@ export async function queryModelMeta(query: ModelMetaQuery): Promise<ModelMetaRe
       return { ok: false, models: [], error: 'Invalid query' };
     }
 
-    const catalog = runtime.getModels() as readonly CatalogEntry[];
+    const catalog = runtime.getModels() as readonly CatalogModelEntry[];
     return {
       ok: true,
       models: query.modelIds.map((modelId) =>
-        mapCatalogFallback(
-          modelId,
-          catalog.find((entry) => entry.id === modelId)
-        )
+        mapCatalogFallback(modelId, findCatalogModelById(catalog, modelId))
       ),
     };
   } catch (error) {

--- a/src/renderer/stores/modelMeta.ts
+++ b/src/renderer/stores/modelMeta.ts
@@ -1,4 +1,13 @@
-import type { ModelMeta, ModelProvider } from '@shared/types';
+import {
+  type CustomModelResolveSource,
+  type ResolvedCustomModelCapabilities,
+  resolveCustomModelView,
+} from '@shared/modelCatalog';
+import type { ModelEntry, ModelMeta, ModelProvider } from '@shared/types';
+
+export type { CustomModelResolveSource, ResolvedCustomModelCapabilities };
+export { resolveCustomModelView };
+
 import { useEffect, useMemo } from 'react';
 import { create } from 'zustand';
 import { useSettingsStore } from '@/stores/settings';
@@ -88,4 +97,15 @@ export function useModelMeta(provider: ModelProvider | undefined): Record<string
     }
     return models;
   }, [cache, provider]);
+}
+
+/**
+ * 自定义 apiKey 行的能力分层。OAuth 行不要用这个——订阅只读 catalog。
+ * `catalogMeta` 来自 `useModelMeta`；未加载时按 catalog 未命中（乐观默认）处理。
+ */
+export function resolveCustomModelMeta(
+  entry: ModelEntry | undefined,
+  catalogMeta: ModelMeta | undefined
+): ResolvedCustomModelCapabilities {
+  return resolveCustomModelView(entry, catalogMeta);
 }

--- a/src/shared/modelCatalog.test.ts
+++ b/src/shared/modelCatalog.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findCatalogModelById,
+  pickModelCapabilityOverrides,
+  positiveFiniteNumber,
+  resolveCustomModelCapabilities,
+  resolveCustomModelView,
+  thinkingLevelMapForCap,
+} from './modelCatalog';
+
+const sonnetCatalog = {
+  id: 'claude-sonnet-4',
+  reasoning: true,
+  thinkingLevelMap: { max: 'max' },
+  contextWindow: 200_000,
+  maxTokens: 64_000,
+} as const;
+
+const noReasoningCatalog = {
+  id: 'gpt-4.1',
+  reasoning: false,
+  contextWindow: 1_047_576,
+  maxTokens: 32_768,
+} as const;
+
+describe('findCatalogModelById', () => {
+  it('只按精确 id 命中，不按前缀', () => {
+    const catalog = [sonnetCatalog, { id: 'claude-sonnet-4-5', reasoning: true }];
+    expect(findCatalogModelById(catalog, 'claude-sonnet-4')).toEqual(sonnetCatalog);
+    expect(findCatalogModelById(catalog, 'claude-sonnet')).toBeUndefined();
+    expect(findCatalogModelById(catalog, 'claude-sonnet-4-5')?.id).toBe('claude-sonnet-4-5');
+  });
+});
+
+describe('pickModelCapabilityOverrides', () => {
+  it('空 / 非法覆盖视为跟随，不发明数字', () => {
+    expect(pickModelCapabilityOverrides(undefined)).toEqual({});
+    expect(
+      pickModelCapabilityOverrides({
+        reasoning: 'follow' as never,
+        thinkingLevel: '' as never,
+        contextWindow: 0,
+        maxTokens: Number.NaN,
+      })
+    ).toEqual({});
+  });
+
+  it('只保留合法覆盖', () => {
+    expect(
+      pickModelCapabilityOverrides({
+        reasoning: 'off',
+        thinkingLevel: 'high',
+        contextWindow: 128_000,
+        maxTokens: 8_000,
+      })
+    ).toEqual({
+      reasoning: 'off',
+      thinkingLevel: 'high',
+      contextWindow: 128_000,
+      maxTokens: 8_000,
+    });
+  });
+});
+
+describe('resolveCustomModelCapabilities', () => {
+  it('catalog 命中官方 id 时用 catalog 的 reasoning / 档位 / 窗口', () => {
+    const resolved = resolveCustomModelCapabilities(sonnetCatalog, {});
+    expect(resolved.reasoning).toBe(true);
+    expect(resolved.thinkingLevelMap).toEqual({ max: 'max' });
+    expect(resolved.thinkingLevels).toEqual(['low', 'medium', 'high', 'max']);
+    expect(resolved.contextWindow).toBe(200_000);
+    expect(resolved.maxTokens).toBe(64_000);
+    expect(resolved.source).toEqual({
+      reasoning: 'catalog',
+      thinkingLevel: 'catalog',
+      contextWindow: 'catalog',
+      maxTokens: 'catalog',
+    });
+  });
+
+  it('catalog 命中但 reasoning:false 时不套乐观 {max:max}', () => {
+    const resolved = resolveCustomModelCapabilities(noReasoningCatalog);
+    expect(resolved.reasoning).toBe(false);
+    expect(resolved.thinkingLevelMap).toBeUndefined();
+    expect(resolved.thinkingLevels).toEqual([]);
+    expect(resolved.source.reasoning).toBe('catalog');
+    expect(resolved.source.thinkingLevel).toBe('catalog');
+  });
+
+  it('catalog 未命中保持今日乐观默认，窗口不填假数字', () => {
+    const resolved = resolveCustomModelCapabilities(undefined, {});
+    expect(resolved.reasoning).toBe(true);
+    expect(resolved.thinkingLevelMap).toEqual({ max: 'max' });
+    expect(resolved.thinkingLevels).toEqual(['low', 'medium', 'high', 'max']);
+    expect(resolved.contextWindow).toBeUndefined();
+    expect(resolved.maxTokens).toBeUndefined();
+    expect(resolved.source).toEqual({
+      reasoning: 'default',
+      thinkingLevel: 'default',
+      contextWindow: 'default',
+      maxTokens: 'default',
+    });
+  });
+
+  it('行覆盖压过 catalog', () => {
+    const resolved = resolveCustomModelCapabilities(sonnetCatalog, {
+      reasoning: 'off',
+      thinkingLevel: 'low',
+      contextWindow: 64_000,
+      maxTokens: 4_000,
+    });
+    expect(resolved.reasoning).toBe(false);
+    expect(resolved.thinkingLevelMap).toBeUndefined();
+    expect(resolved.thinkingLevels).toEqual([]);
+    expect(resolved.contextWindow).toBe(64_000);
+    expect(resolved.maxTokens).toBe(4_000);
+    expect(resolved.source).toEqual({
+      reasoning: 'override',
+      thinkingLevel: 'override',
+      contextWindow: 'override',
+      maxTokens: 'override',
+    });
+  });
+
+  it('只覆盖思考档时 reasoning 仍跟随 catalog', () => {
+    const resolved = resolveCustomModelCapabilities(sonnetCatalog, { thinkingLevel: 'high' });
+    expect(resolved.reasoning).toBe(true);
+    expect(resolved.thinkingLevelMap).toBeUndefined();
+    expect(resolved.thinkingLevels).toEqual(['low', 'medium', 'high']);
+    expect(resolved.source.reasoning).toBe('catalog');
+    expect(resolved.source.thinkingLevel).toBe('override');
+    expect(resolved.source.contextWindow).toBe('catalog');
+  });
+
+  it('空覆盖跟随 catalog；未命中则跟随乐观默认', () => {
+    const followCatalog = resolveCustomModelCapabilities(sonnetCatalog, {
+      reasoning: undefined,
+      thinkingLevel: undefined,
+      contextWindow: undefined,
+      maxTokens: undefined,
+    });
+    expect(followCatalog.source.reasoning).toBe('catalog');
+    expect(followCatalog.reasoning).toBe(sonnetCatalog.reasoning);
+    expect(followCatalog.thinkingLevelMap).toEqual(sonnetCatalog.thinkingLevelMap);
+
+    const followDefault = resolveCustomModelCapabilities(undefined, {
+      reasoning: 'on' as const,
+    });
+    expect(followDefault.reasoning).toBe(true);
+    expect(followDefault.source.reasoning).toBe('override');
+    expect(followDefault.thinkingLevelMap).toEqual({ max: 'max' });
+    expect(followDefault.source.thinkingLevel).toBe('default');
+  });
+
+  it('reasoning:on 覆盖在 catalog 未命中时仍用乐观档', () => {
+    const resolved = resolveCustomModelCapabilities(undefined, { reasoning: 'on' });
+    expect(resolved.reasoning).toBe(true);
+    expect(resolved.thinkingLevelMap).toEqual({ max: 'max' });
+    expect(resolved.source.thinkingLevel).toBe('default');
+  });
+});
+
+describe('thinkingLevelMapForCap', () => {
+  it('max 显式声明，high 不声明 max，更低档剔除更高项目档', () => {
+    expect(thinkingLevelMapForCap('max')).toEqual({ max: 'max' });
+    expect(thinkingLevelMapForCap('high')).toBeUndefined();
+    expect(thinkingLevelMapForCap('medium')).toEqual({ high: null });
+    expect(thinkingLevelMapForCap('low')).toEqual({ medium: null, high: null });
+  });
+});
+
+describe('resolveCustomModelView', () => {
+  it('catalog-fallback meta + 行覆盖：覆盖赢，source 可读', () => {
+    const view = resolveCustomModelView(
+      { reasoning: 'off', contextWindow: 64_000 },
+      {
+        modelId: 'claude-sonnet-4',
+        source: 'catalog-fallback',
+        reasoning: true,
+        thinkingLevels: ['low', 'medium', 'high', 'max'],
+        contextWindow: 200_000,
+        maxTokens: 64_000,
+      }
+    );
+    expect(view.reasoning).toBe(false);
+    expect(view.source.reasoning).toBe('override');
+    expect(view.source.thinkingLevel).toBe('catalog');
+    expect(view.contextWindow).toBe(64_000);
+    expect(view.source.contextWindow).toBe('override');
+    expect(view.maxTokens).toBe(64_000);
+    expect(view.source.maxTokens).toBe('catalog');
+  });
+
+  it('unknown meta 且无覆盖 → 乐观默认', () => {
+    const view = resolveCustomModelView(undefined, {
+      modelId: 'relay-foo',
+      source: 'unknown',
+    });
+    expect(view.source.reasoning).toBe('default');
+    expect(view.thinkingLevelMap).toEqual({ max: 'max' });
+  });
+});
+
+describe('positiveFiniteNumber', () => {
+  it('非正 / 非有限视为缺失', () => {
+    expect(positiveFiniteNumber(128_000)).toBe(128_000);
+    expect(positiveFiniteNumber(0)).toBeUndefined();
+    expect(positiveFiniteNumber(-1)).toBeUndefined();
+    expect(positiveFiniteNumber(Number.NaN)).toBeUndefined();
+    expect(positiveFiniteNumber(undefined)).toBeUndefined();
+  });
+});

--- a/src/shared/modelCatalog.ts
+++ b/src/shared/modelCatalog.ts
@@ -1,0 +1,229 @@
+import { supportedProjectThinkingLevels } from './modelThinking';
+import { THINKING_LEVELS, type ThinkingLevel } from './types/agent';
+import type {
+  ModelCapabilityOverrides,
+  ModelReasoningOverride,
+  ModelThinkingLevelOverride,
+} from './types/llm';
+import { MODEL_REASONING_OVERRIDES, MODEL_THINKING_LEVEL_OVERRIDES } from './types/llm';
+import type { ModelMeta } from './types/modelMeta';
+
+/** runtime.getModels() 条目里 resolve / ModelMeta 实际会读的字段 */
+export interface CatalogModelEntry {
+  id: string;
+  contextWindow?: number;
+  maxTokens?: number;
+  reasoning?: boolean;
+  thinkingLevelMap?: Record<string, string | null | undefined>;
+}
+
+/** 自定义模型能力分层：行覆盖 > 精确 catalog id > 乐观默认 */
+export const CUSTOM_MODEL_RESOLVE_SOURCES = ['override', 'catalog', 'default'] as const;
+export type CustomModelResolveSource = (typeof CUSTOM_MODEL_RESOLVE_SOURCES)[number];
+
+export interface CustomModelFieldSources {
+  reasoning: CustomModelResolveSource;
+  thinkingLevel: CustomModelResolveSource;
+  contextWindow: CustomModelResolveSource;
+  maxTokens: CustomModelResolveSource;
+}
+
+export interface ResolvedCustomModelCapabilities {
+  reasoning: boolean;
+  thinkingLevelMap?: Record<string, string | null | undefined>;
+  /** 缺省 = 数据层未知；spawn 再套 128K，这里不填假数字 */
+  contextWindow?: number;
+  maxTokens?: number;
+  thinkingLevels: ThinkingLevel[];
+  source: CustomModelFieldSources;
+}
+
+const OPTIMISTIC_THINKING_LEVEL_MAP = { max: 'max' } as const;
+
+/** 精确 model id 查找。OAuth meta 与自定义 spawn 共用；禁止前缀 / 品牌猜测。 */
+export function findCatalogModelById<T extends { id: string }>(
+  catalog: readonly T[],
+  modelId: string
+): T | undefined {
+  return catalog.find((entry) => entry.id === modelId);
+}
+
+/** 非正 / 非有限视为缺失。未知不得用 128K 凑数。 */
+export function positiveFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export function positiveContextWindow(
+  model: { contextWindow?: number } | undefined
+): number | undefined {
+  return positiveFiniteNumber(model?.contextWindow);
+}
+
+export function isModelReasoningOverride(value: unknown): value is ModelReasoningOverride {
+  return (
+    typeof value === 'string' && (MODEL_REASONING_OVERRIDES as readonly string[]).includes(value)
+  );
+}
+
+export function isModelThinkingLevelOverride(value: unknown): value is ModelThinkingLevelOverride {
+  return (
+    typeof value === 'string' &&
+    (MODEL_THINKING_LEVEL_OVERRIDES as readonly string[]).includes(value)
+  );
+}
+
+/** 只抽出已设置且合法的覆盖；空 / 非法 = 跟随，不往下一层传假值。 */
+export function pickModelCapabilityOverrides(
+  entry: ModelCapabilityOverrides | undefined
+): ModelCapabilityOverrides {
+  if (!entry) return {};
+  const overrides: ModelCapabilityOverrides = {};
+  if (isModelReasoningOverride(entry.reasoning)) overrides.reasoning = entry.reasoning;
+  if (isModelThinkingLevelOverride(entry.thinkingLevel)) {
+    overrides.thinkingLevel = entry.thinkingLevel;
+  }
+  const contextWindow = positiveFiniteNumber(entry.contextWindow);
+  if (contextWindow !== undefined) overrides.contextWindow = contextWindow;
+  const maxTokens = positiveFiniteNumber(entry.maxTokens);
+  if (maxTokens !== undefined) overrides.maxTokens = maxTokens;
+  return overrides;
+}
+
+/**
+ * 行覆盖把「最高支持档」写成 thinkingLevelMap：
+ * max 显式声明；更低档用 null 剔除更高项目档（max 未声明本身就不支持）。
+ */
+export function thinkingLevelMapForCap(
+  level: ThinkingLevel
+): Record<string, string | null> | undefined {
+  if (level === 'max') return { max: 'max' };
+  if (level === 'high') return undefined;
+  const map: Record<string, string | null> = {};
+  const start = THINKING_LEVELS.indexOf(level) + 1;
+  for (let i = start; i < THINKING_LEVELS.length; i++) {
+    const higher = THINKING_LEVELS[i];
+    if (higher && higher !== 'max') map[higher] = null;
+  }
+  return Object.keys(map).length > 0 ? map : undefined;
+}
+
+export function resolveCustomModelCapabilities(
+  catalog: CatalogModelEntry | undefined,
+  overrides?: ModelCapabilityOverrides
+): ResolvedCustomModelCapabilities {
+  const picked = pickModelCapabilityOverrides(overrides);
+  const catalogHit = catalog !== undefined;
+
+  const reasoning = resolveReasoning(catalog, picked);
+  const thinking = resolveThinkingLevelMap(catalog, picked, catalogHit, reasoning.value);
+  const contextWindow = resolvePositive(
+    picked.contextWindow,
+    catalogHit ? positiveFiniteNumber(catalog?.contextWindow) : undefined,
+    catalogHit
+  );
+  const maxTokens = resolvePositive(
+    picked.maxTokens,
+    catalogHit ? positiveFiniteNumber(catalog?.maxTokens) : undefined,
+    catalogHit
+  );
+
+  const thinkingLevelMap = reasoning.value ? thinking.value : undefined;
+  return {
+    reasoning: reasoning.value,
+    ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
+    ...(contextWindow.value !== undefined ? { contextWindow: contextWindow.value } : {}),
+    ...(maxTokens.value !== undefined ? { maxTokens: maxTokens.value } : {}),
+    thinkingLevels: supportedProjectThinkingLevels({
+      reasoning: reasoning.value,
+      thinkingLevelMap,
+    }),
+    source: {
+      reasoning: reasoning.source,
+      thinkingLevel: thinking.source,
+      contextWindow: contextWindow.source,
+      maxTokens: maxTokens.source,
+    },
+  };
+}
+
+function resolveReasoning(
+  catalog: CatalogModelEntry | undefined,
+  picked: ModelCapabilityOverrides
+): { value: boolean; source: CustomModelResolveSource } {
+  if (picked.reasoning === 'on') return { value: true, source: 'override' };
+  if (picked.reasoning === 'off') return { value: false, source: 'override' };
+  if (catalog && typeof catalog.reasoning === 'boolean') {
+    return { value: catalog.reasoning, source: 'catalog' };
+  }
+  return { value: true, source: 'default' };
+}
+
+function resolveThinkingLevelMap(
+  catalog: CatalogModelEntry | undefined,
+  picked: ModelCapabilityOverrides,
+  catalogHit: boolean,
+  reasoningEnabled: boolean
+): {
+  value: Record<string, string | null | undefined> | undefined;
+  source: CustomModelResolveSource;
+} {
+  if (picked.thinkingLevel) {
+    return {
+      value: thinkingLevelMapForCap(picked.thinkingLevel),
+      source: 'override',
+    };
+  }
+  if (catalogHit) {
+    return {
+      value: catalog?.thinkingLevelMap,
+      source: 'catalog',
+    };
+  }
+  return {
+    value: reasoningEnabled ? { ...OPTIMISTIC_THINKING_LEVEL_MAP } : undefined,
+    source: 'default',
+  };
+}
+
+/** 把 queryModelMeta 的结果还原成 catalog 快照，供 UI 叠行覆盖并读 source。 */
+export function catalogFromModelMeta(meta: ModelMeta | undefined): CatalogModelEntry | undefined {
+  if (!meta || meta.source === 'unknown') return undefined;
+  return {
+    id: meta.modelId,
+    reasoning: meta.reasoning,
+    contextWindow: meta.contextWindow,
+    maxTokens: meta.maxTokens,
+    thinkingLevelMap: thinkingLevelMapFromProjectLevels(meta.reasoning, meta.thinkingLevels),
+  };
+}
+
+/** 设置行 UI：ModelEntry 覆盖 + 已查到的 ModelMeta → 分层结果（含 source） */
+export function resolveCustomModelView(
+  entry: ModelCapabilityOverrides | undefined,
+  meta: ModelMeta | undefined
+): ResolvedCustomModelCapabilities {
+  return resolveCustomModelCapabilities(catalogFromModelMeta(meta), entry);
+}
+
+function thinkingLevelMapFromProjectLevels(
+  reasoning: boolean | undefined,
+  levels: ThinkingLevel[] | undefined
+): Record<string, string | null> | undefined {
+  if (reasoning !== true || !levels) return undefined;
+  const map: Record<string, string | null> = {};
+  if (levels.includes('max')) map.max = 'max';
+  for (const level of ['low', 'medium', 'high'] as const) {
+    if (!levels.includes(level)) map[level] = null;
+  }
+  return Object.keys(map).length > 0 ? map : undefined;
+}
+
+function resolvePositive(
+  override: number | undefined,
+  catalogValue: number | undefined,
+  catalogHit: boolean
+): { value: number | undefined; source: CustomModelResolveSource } {
+  if (override !== undefined) return { value: override, source: 'override' };
+  if (catalogHit) return { value: catalogValue, source: 'catalog' };
+  return { value: undefined, source: 'default' };
+}

--- a/src/shared/types/agent.ts
+++ b/src/shared/types/agent.ts
@@ -1,10 +1,10 @@
-import type { ModelApiKind } from './llm';
+import type { ModelApiKind, ModelCapabilityOverrides } from './llm';
 
 /** 会话状态。waiting/done 属权限门与 subagent 刀，M1 不引入 */
 export type NodeStatus = 'idle' | 'running' | 'failed';
 
 /** spawn 下发的模型配置。apiKey 只在 Main → worker 方向出现，事件类型不给 auth 位置 */
-export interface SpawnModelConfig {
+export interface SpawnModelConfig extends ModelCapabilityOverrides {
   api: ModelApiKind;
   baseUrl: string;
   apiKey: string;

--- a/src/shared/types/llm.ts
+++ b/src/shared/types/llm.ts
@@ -9,7 +9,26 @@ export const MODEL_API_KINDS = [
 
 export type ModelApiKind = (typeof MODEL_API_KINDS)[number];
 
-export interface ModelEntry {
+/** 行级推理覆盖：未设 / 空 = 跟随 catalog 或乐观默认。不要存 `'follow'`。 */
+export const MODEL_REASONING_OVERRIDES = ['on', 'off'] as const;
+export type ModelReasoningOverride = (typeof MODEL_REASONING_OVERRIDES)[number];
+
+/**
+ * 行级最高思考档覆盖，值域与 `THINKING_LEVELS` 对齐。
+ * 写在 llm 以免 `types/agent` ↔ `types/llm` 循环依赖。
+ */
+export const MODEL_THINKING_LEVEL_OVERRIDES = ['low', 'medium', 'high', 'max'] as const;
+export type ModelThinkingLevelOverride = (typeof MODEL_THINKING_LEVEL_OVERRIDES)[number];
+
+/** 自定义模型行的可选能力覆盖。缺省字段 = 跟随上一层，不在数据层填假数字。 */
+export interface ModelCapabilityOverrides {
+  reasoning?: ModelReasoningOverride;
+  thinkingLevel?: ModelThinkingLevelOverride;
+  contextWindow?: number;
+  maxTokens?: number;
+}
+
+export interface ModelEntry extends ModelCapabilityOverrides {
   id: string;
   label?: string;
   /** 是否启用（缺省视为启用） */

--- a/src/shared/types/modelMeta.ts
+++ b/src/shared/types/modelMeta.ts
@@ -24,7 +24,11 @@ export interface ModelMeta {
    * ⚠️「缺失」与「空数组」语义不同，序列化/反序列化都不许把 undefined 归一成 []。
    */
   thinkingLevels?: ThinkingLevel[];
-  /** 仅用于 UI 打「估算」标记与排障，⛔ 不参与任何逻辑判定 */
+  /**
+   * 查询路径来源：订阅 catalog / 自定义 id 反查 / 未命中。
+   * 自定义行的能力分层（override / catalog / default）见 `resolveCustomModelCapabilities`，
+   * 不挤进这个字段——OAuth 路径保持 catalog-only。
+   */
   source: 'catalog' | 'catalog-fallback' | 'unknown';
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Custom `apiKey` / relay models no longer register with hardcoded `reasoning: true` + `thinkingLevelMap: { max: 'max' }`. Spawn now uses the same exact-id catalog table OAuth already reads.

**Resolution order for apiKey / custom models (locked):**
1. Model-row overrides (if set) win
2. Else catalog hit by **exact model id**
3. Else today's optimistic default (`reasoning: true` + `{ max: 'max' }`)

OAuth subscription models stay catalog-only / read-only. Row overrides are not persisted or applied on oauth rows.

## What changed

- Shared helper `findCatalogModelById` + `resolveCustomModelCapabilities` in `src/shared/modelCatalog.ts` — used by both `queryModelMeta` and `resolveBaseModel`
- `ModelEntry` / `SpawnModelConfig` gain optional overrides: `reasoning` (`on` / `off`), `thinkingLevel`, `contextWindow`, `maxTokens`. Unset / empty / non-positive = follow parent layer. No invented default numbers in the data layer
- `agentHost` threads apiKey row overrides into spawn; oauth path ignores them
- Custom catalog-fallback meta now reports catalog `reasoning` / `thinkingLevels` so spawn and UI stay consistent
- UI helper: `resolveCustomModelMeta` / `resolveCustomModelView` expose per-field `source`: `override` | `catalog` | `default`
- Settings expand-row UI, badges, and CDP scripts are **not** in this PR (designer-owned)

## Issue

Closes #6

This PR targets `feature/model-ui-and-status-line`, not the default branch. GitHub will **not** auto-close the issue on merge — close #6 manually when this lands on the intended branch.

## Verification

- `pnpm exec vitest` on touched files: 24 targeted tests passed (plus related supervisor / modelThinking suites, 34 total)
- `pnpm typecheck` clean

## Out of scope

- Settings row expand UI / badges
- Temperature, top_p, persona, or other sampling knobs
- Prefix / brand matching (`id.startsWith('claude')`)
- OAuth override persistence

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f79b05fd-50e2-4192-b0d3-7e1b2c51869e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f79b05fd-50e2-4192-b0d3-7e1b2c51869e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

