### PR TITLE
fix: Agent type 同名覆盖语义统一 + @ 弹层键盘高亮浅色主题不可见

### DIFF
--- a/src/main/services/agentHost.ts
+++ b/src/main/services/agentHost.ts
@@ -468,7 +468,8 @@ function configuredAgentTypes(
       : []
   );
   const custom = Array.isArray(state?.agentTypes) ? state.agentTypes.filter(isAgentTypeEntry) : [];
-  const customNames = new Set(custom.map((entry) => entry.name));
+  // 与 registry 同口径（trim + 小写）：同名 custom 覆盖 builtin
+  const customNames = new Set(custom.map((entry) => entry.name.trim().toLowerCase()));
   const builtins = BUILTIN_AGENT_TYPES.filter(
     (type) => !disabled.has(type.name) && !customNames.has(type.name)
   ).map((type) => ({

--- a/src/renderer/components/chat/Composer.tsx
+++ b/src/renderer/components/chat/Composer.tsx
@@ -382,7 +382,8 @@ export function Composer({
               onMouseEnter={() => setActiveIndex(index)}
               className={cn(
                 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs',
-                index === activeIndex && 'bg-muted'
+                // 同 MentionPicker：浅色主题下 bg-muted 在纯白 popover 上不可见
+                index === activeIndex && 'bg-foreground/10'
               )}
             >
               <SlashSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/src/renderer/components/chat/CoworkerTabs.tsx
+++ b/src/renderer/components/chat/CoworkerTabs.tsx
@@ -127,8 +127,8 @@ function HireCoworkerDialog({ parentId, onClose }: { parentId: string; onClose: 
   const [name, setName] = React.useState('');
   const [agentType, setAgentType] = React.useState('');
   const [error, setError] = React.useState<string | null>(null);
-  // 与 main 下发口径一致：内置(过滤已关闭)+ 自定义(同名覆盖内置)
-  const customNames = new Set(agentTypes.map((entry) => entry.name));
+  // 与 main 下发口径一致：内置(过滤已关闭)+ 自定义(同名覆盖内置，trim+小写同口径)
+  const customNames = new Set(agentTypes.map((entry) => entry.name.trim().toLowerCase()));
   const typeNames = [
     ...BUILTIN_AGENT_TYPES.filter(
       (type) => !disabledBuiltins.includes(type.name) && !customNames.has(type.name)

--- a/src/renderer/components/chat/MentionPicker.tsx
+++ b/src/renderer/components/chat/MentionPicker.tsx
@@ -119,7 +119,9 @@ function MentionOption({
       onMouseEnter={onMouseEnter}
       className={cn(
         'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs',
-        active && 'bg-muted'
+        // 浅色主题下 popover(纯白)与 muted 亮度差仅 0.035，高亮几乎不可见；
+        // 用前景色衍生的透明度保证两种主题都有对比度。
+        active && 'bg-foreground/10'
       )}
     >
       <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border bg-background">

--- a/src/renderer/components/settings/AgentTypesSettings.tsx
+++ b/src/renderer/components/settings/AgentTypesSettings.tsx
@@ -49,6 +49,12 @@ export function AgentTypeList() {
   const [editing, setEditing] = React.useState<
     AgentTypeEntry | 'new' | { defaults: Omit<AgentTypeEntry, 'id'> } | null
   >(null);
+  // 同名自定义覆盖内置：被覆盖的内置行隐藏（与 registry / 编码工具路径同口径），
+  // 否则设置页会出现两个同名行，且内置行的开关看似有效实则已被顶替。
+  const overriddenNames = React.useMemo(
+    () => new Set(agentTypes.map((entry) => entry.name.trim().toLowerCase())),
+    [agentTypes]
+  );
 
   return (
     <div className="space-y-2">
@@ -79,7 +85,7 @@ export function AgentTypeList() {
         </div>
       </div>
 
-      {BUILTIN_AGENT_TYPES.map((type) => (
+      {BUILTIN_AGENT_TYPES.filter((type) => !overriddenNames.has(type.name)).map((type) => (
         <div key={type.name} className="flex items-center gap-3 rounded-md border px-3 py-2.5">
           <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
           <div className="min-w-0 flex-1">
@@ -108,6 +114,9 @@ export function AgentTypeList() {
             <div className="min-w-0 flex-1">
               <p className="flex items-center gap-2 truncate text-sm font-medium">
                 {entry.name}
+                {BUILTIN_AGENT_TYPES.some(
+                  (type) => type.name === entry.name.trim().toLowerCase()
+                ) && <Badge variant="secondary">{t('Overrides built-in')}</Badge>}
                 {entry.tools === 'readonly' && <Badge variant="outline">{t('Read-only')}</Badge>}
               </p>
               <p className="truncate text-muted-foreground text-xs">
@@ -165,7 +174,7 @@ export function AgentTypeEditDialog({
   onClose,
 }: {
   entry: AgentTypeEntry | null;
-  /** 编辑内置时的预填内容（保存生成独立 custom type；registry 以 typeKey 区分同名项） */
+  /** 编辑内置时的预填内容（保存生成同名 custom 覆盖，内置行随之隐藏；删除 custom 后内置恢复） */
   defaults?: Omit<AgentTypeEntry, 'id'>;
   onClose: () => void;
 }) {

--- a/src/shared/builtinAgents.test.ts
+++ b/src/shared/builtinAgents.test.ts
@@ -48,7 +48,7 @@ describe('AgentType registry and locked Enso profile', () => {
     expect(isReservedAgentTypeName('reviewer')).toBe(false);
   });
 
-  it('registry 过滤 disabled builtin/非法 custom，但允许 builtin/custom 同名', () => {
+  it('registry 过滤 disabled builtin/非法 custom；同名合法 custom 覆盖 builtin', () => {
     const snapshot = buildAgentTypeRegistrySnapshot({
       revision: 3,
       disabledBuiltinAgentTypes: ['worker'],
@@ -71,11 +71,44 @@ describe('AgentType registry and locked Enso profile', () => {
     });
     expect(snapshot.candidates.map((candidate) => candidate.typeKey)).toEqual([
       'agent:enso',
-      'builtin:scout',
       'builtin:reviewer',
       `custom:${CUSTOM_ID}`,
     ]);
     expect(parseAgentTypeRegistrySnapshot(snapshot)).toEqual(snapshot);
+
+    // 非法 custom（非 UUID id）不产生覆盖：builtin 保留
+    const withIllegal = buildAgentTypeRegistrySnapshot({
+      revision: 4,
+      disabledBuiltinAgentTypes: [],
+      customAgentTypes: [
+        {
+          id: 'not-a-uuid',
+          name: 'scout',
+          description: 'x',
+          systemPrompt: 'x',
+          tools: 'readonly',
+        },
+      ],
+    });
+    expect(withIllegal.candidates.map((candidate) => candidate.typeKey)).toContain('builtin:scout');
+
+    // 覆盖名称对比徽 trim + 大小写不敏感（与 reserved 名校验同口径）
+    const caseInsensitive = buildAgentTypeRegistrySnapshot({
+      revision: 5,
+      disabledBuiltinAgentTypes: [],
+      customAgentTypes: [
+        {
+          id: CUSTOM_ID,
+          name: ' Scout ',
+          description: 'x',
+          systemPrompt: 'x',
+          tools: 'readonly',
+        },
+      ],
+    });
+    expect(caseInsensitive.candidates.map((candidate) => candidate.typeKey)).not.toContain(
+      'builtin:scout'
+    );
   });
 
   it('type key 严格拒绝未知形态与 reserved custom', () => {

--- a/src/shared/builtinAgents.ts
+++ b/src/shared/builtinAgents.ts
@@ -234,6 +234,14 @@ export function buildAgentTypeRegistrySnapshot(input: {
   customAgentTypes: readonly AgentTypeEntry[];
 }): AgentTypeRegistrySnapshot {
   const disabled = new Set(input.disabledBuiltinAgentTypes);
+  // 同名合法 custom 覆盖 builtin（仅 Enso 受 reserved 名保护）：名字在
+  // 编码会话的 subagent/coworker 工具里就是类型的唯一键，同名并存在那条
+  // 路径上无法干净表达；这里同步过滤，保证 @ 候选与工具可用集一致。
+  const overriddenNames = new Set(
+    input.customAgentTypes
+      .filter((entry) => isUuid(entry.id) && !isReservedAgentTypeName(entry.name))
+      .map((entry) => entry.name.trim().toLowerCase())
+  );
   const candidates: AgentTypeCandidate[] = [
     {
       typeKey: ENSO_AGENT_TYPE_KEY,
@@ -246,7 +254,12 @@ export function buildAgentTypeRegistrySnapshot(input: {
     },
   ];
   for (const builtin of BUILTIN_AGENT_TYPES) {
-    if (builtin.name === 'general' || builtin.name === 'enso' || disabled.has(builtin.name)) {
+    if (
+      builtin.name === 'general' ||
+      builtin.name === 'enso' ||
+      disabled.has(builtin.name) ||
+      overriddenNames.has(builtin.name)
+    ) {
       continue;
     }
     candidates.push({

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -463,6 +463,7 @@ export const zhTranslations: Record<string, string> = {
   'Follows the conversation model, full toolset': '跟随会话模型,全部工具',
   'Follows the conversation model': '跟随会话模型',
   'Read-only': '只读',
+  'Overrides built-in': '覆盖内置',
   'Edit agent type': '编辑类型',
   'Name (slug)': '名称(slug)',
   'Description (helps the agent pick this type)': '描述(帮助主 agent 选型)',


### PR DESCRIPTION
## 两个用户报障的修复

### 1. 同名自定义 Agent type 出现两行（`bf7b4fd`）

模型中心重构把 registry 改成同名并存（typeKey 区分），但编码会话的 subagent/coworker 工具路径仍是名字键的覆盖语义，设置页则两行并显 —— 同一个「同名」在三个面上语义各不相同：
- `@` 候选里出现两个 scout
- 编码工具里 builtin 被 custom 静默顶掉（尽管设置页开关还开着）
- 设置页两行几乎一样，custom 行无标识

**统一为覆盖语义**（名字在工具路径就是类型唯一键，同名并存在那里无法干净表达）：
- registry 过滤被合法 custom 同名覆盖的 builtin（trim+小写同口径）
- 设置页隐藏被覆盖的内置行，custom 行加「覆盖内置」徽标
- agentHost / CoworkerTabs 名字归一化对齐
- 删除 custom 后 builtin 恢复（真机验证）
- 派发侧 fail-closed 不变：指向被覆盖 `builtin:scout` 的陈旧 chip 被拒绝，不会静默落到 custom

### 2. 「@ 没法用键盘控制上下」（`5a9a829`）

排查结论：键盘逻辑一直是好的（activeIndex 在动，scrollIntoView 的轻微滚动就是证据），**坏的是视觉**——选中态 `bg-muted` 在浅色主题下与纯白 popover 亮度差仅 0.035（oklch 0.965 vs 1.0），高亮等于不可见；深色主题差 0.124 所以从没被发现。

改用前景色衍生的 `bg-foreground/10`，两种主题都有保证的对比度。`@` 弹层与 slash 命令列表同步修。

## 验证

- typecheck 干净 / 86 文件 691 测试全绿 / biome 0 error / build 通过
- 真机：创建同名 scout → registry 中 builtin:scout 消失、设置页单行带「覆盖内置」徽标；删除后恢复
- 真机截图确认浅色主题下高亮清晰可见