### PR TITLE
fix: running 中「立即发送」的消息闪没

### DIFF
--- a/src/renderer/stores/sessions/index.ts
+++ b/src/renderer/stores/sessions/index.ts
@@ -689,13 +689,17 @@ export const useSessionsStore = create<SessionsState>()(
           patch(state, id, {
             messages: [
               ...state.conversations[id].messages,
-              { role: 'user', content: [{ type: 'text' as const, text }], timestamp: Date.now() },
+              {
+                role: 'user',
+                content: [{ type: 'text' as const, text }],
+                timestamp: Date.now(),
+                optimistic: true,
+              },
             ],
           })
         );
         void window.electronAPI.agent.prompt(id, text, undefined);
       }
-
       /** 逐条投递排队消息:每次轮次收束只发队首一条(每条获得完整一轮),下轮结束再发下一条 */
       function flushQueue(id: string): void {
         const conversation = get().conversations[id];
@@ -721,6 +725,7 @@ export const useSessionsStore = create<SessionsState>()(
                   ...(next.images ?? []).map((image) => ({ type: 'image' as const, ...image })),
                 ],
                 timestamp: Date.now(),
+                optimistic: true,
               },
             ],
           })
@@ -1102,8 +1107,8 @@ export const useSessionsStore = create<SessionsState>()(
             );
             return null;
           }
-          // 乐观回显：立即上屏，不等 spawn/prompt 往返。worker 会为这条 user 消息
-          // 发同 index 的 message-upsert（其 messages.length 与本地一致），自然覆盖对齐；
+          // 乐观回显：立即上屏，不等 spawn/prompt 往返。optimistic 标记使其作为
+          // 未确认尾巴浮在权威消息之后，同文本 user upsert 到达时被消费；
           // 万一错位由 agent_end 的全量 reconcile 兜底。
           set((state) =>
             patch(state, id, {
@@ -1116,6 +1121,7 @@ export const useSessionsStore = create<SessionsState>()(
                     ...(images ?? []).map((image) => ({ type: 'image' as const, ...image })),
                   ],
                   timestamp: Date.now(),
+                  optimistic: true,
                 },
               ],
             })
@@ -1368,6 +1374,7 @@ export const useSessionsStore = create<SessionsState>()(
                     role: 'user',
                     content: [{ type: 'text' as const, text: kickoff }],
                     timestamp: Date.now(),
+                    optimistic: true,
                   },
                 ],
               })
@@ -1471,9 +1478,9 @@ export const useSessionsStore = create<SessionsState>()(
           const item = conversation?.queuedMessages?.find((message) => message.id === messageId);
           if (!conversation || !item) return;
           const running = conversation.status === 'running';
-          // 出队并乐观回显。与 sendMessage / flushQueue 同一套：worker 会为这条
-          // user 消息发同 index 的 message-upsert 覆盖对齐。running 分支此前只出队
-          // 不上屏（指望 reconcile 补），一旦没回流用户就看到消息凭空消失。
+          // 出队并乐观回显。optimistic 标记使其浮在权威消息之后：running 时 steer
+          // 要到下一个循环边界才送达，期间当前轮的 assistant upsert 若按裸 index
+          // 覆盖会把回显顶掉（消息凭空消失，轮次结束后又出现）。
           set((state) =>
             patch(state, conversationId, {
               queuedMessages: (state.conversations[conversationId]?.queuedMessages ?? []).filter(
@@ -1488,6 +1495,7 @@ export const useSessionsStore = create<SessionsState>()(
                     ...(item.images ?? []).map((image) => ({ type: 'image' as const, ...image })),
                   ],
                   timestamp: Date.now(),
+                  optimistic: true,
                 },
               ],
             })

--- a/src/renderer/stores/sessions/reducer.test.ts
+++ b/src/renderer/stores/sessions/reducer.test.ts
@@ -53,6 +53,66 @@ describe('applyAgentEvent', () => {
     expect(updated.messages[0].content).toEqual([{ type: 'text', text: 'hi!' }]);
   });
 
+  it('乐观尾巴不被同 index 的 assistant upsert 覆盖，同文本 user upsert 将其消费', () => {
+    // 复现：running 中“立即发送”乐观回显在本地尾部，当前轮的 assistant
+    // upsert 撞同 index 把它覆盖 → 用户看到消息凭空消失，轮次结束后又出现。
+    const withHistory = applyAgentEvent(base, 's1', {
+      type: 'message-upsert',
+      identity: identity(),
+      seq: 1,
+      index: 0,
+      message: { role: 'user', content: [{ type: 'text', text: 'first' }] },
+    });
+    const withEcho = {
+      ...withHistory,
+      messages: [
+        ...withHistory.messages,
+        {
+          role: 'user',
+          content: [{ type: 'text' as const, text: 'steer me' }],
+          optimistic: true as const,
+        },
+      ],
+    };
+
+    // 当前轮的 assistant 消息撞上乐观回显的 index：回显必须浮到它之后而非被覆盖
+    const collided = applyAgentEvent(withEcho, 's1', {
+      type: 'message-upsert',
+      identity: identity(),
+      seq: 2,
+      index: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'working...' }] },
+    });
+    expect(collided.messages.map((message) => message.role)).toEqual(['user', 'assistant', 'user']);
+    expect(collided.messages[2].content).toEqual([{ type: 'text', text: 'steer me' }]);
+
+    // steer 真正送达：同文本的 user upsert 消费掉乐观回显，不产生重复
+    const delivered = applyAgentEvent(collided, 's1', {
+      type: 'message-upsert',
+      identity: identity(),
+      seq: 3,
+      index: 2,
+      message: { role: 'user', content: [{ type: 'text', text: 'steer me' }] },
+    });
+    expect(delivered.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+    ]);
+    expect(delivered.messages[2]).not.toHaveProperty('optimistic', true);
+
+    // 历史区（index < 权威长度）的 upsert 仍是就地覆盖
+    const rewrite = applyAgentEvent(delivered, 's1', {
+      type: 'message-upsert',
+      identity: identity(),
+      seq: 4,
+      index: 0,
+      message: { role: 'user', content: [{ type: 'text', text: 'first!' }] },
+    });
+    expect(rewrite.messages).toHaveLength(3);
+    expect(rewrite.messages[0].content).toEqual([{ type: 'text', text: 'first!' }]);
+  });
+
   it('restored generation replaces the projection and rejects stale generation events', () => {
     const g1 = applyAgentEvent(base, 's1', status(5, 'running', 'g1'));
     const snapshot: SessionSnapshot = {

--- a/src/renderer/stores/sessions/reducer.ts
+++ b/src/renderer/stores/sessions/reducer.ts
@@ -13,11 +13,24 @@ import {
   shouldApplyDispatchMainEvent,
 } from '@shared/types/agent';
 
+/**
+ * 时间线消息：乐观回显（本地先上屏、worker 尚未确认）带 optimistic 标记，
+ * 只允许出现在数组尾部（权威消息之后）。
+ */
+export type TimelineMessage = ProjectedMessage & { optimistic?: boolean };
+
+function textOf(message: ProjectedMessage): string {
+  return message.content
+    .map((part) => (part.type === 'text' ? part.text : ''))
+    .join('\n')
+    .trim();
+}
+
 export interface SessionProjection {
   generation?: string;
   status: NodeStatus;
   error?: string;
-  messages: ProjectedMessage[];
+  messages: TimelineMessage[];
   customEntries: AgentSessionCustomEntry[];
   commands: SlashCommand[];
   lastSeq: number;
@@ -174,9 +187,25 @@ export function applyAgentEvent(
       };
     }
     case 'message-upsert': {
-      const messages = current.messages.slice();
-      messages[event.index] = event.message;
-      return { ...current, messages, lastSeq: event.seq };
+      // 乐观回显是未确认的本地尾巴：权威 upsert 只写权威区，尾巴永远浮在后面。
+      // running 中 steer 的回显若按裸 index 覆盖，会被当前轮的 assistant 消息
+      // 顶掉（用户看到消息凭空消失，轮次结束后又出现）。
+      const firstOptimistic = current.messages.findIndex((message) => message.optimistic);
+      const authoritative =
+        firstOptimistic === -1
+          ? current.messages.slice()
+          : current.messages.slice(0, firstOptimistic);
+      let tail = firstOptimistic === -1 ? [] : current.messages.slice(firstOptimistic);
+      authoritative[event.index] = event.message;
+      // 同文本的 user upsert 到达 = 回显对应的真消息落地，消费掉避免重复
+      if (event.message.role === 'user' && tail.length > 0) {
+        const deliveredText = textOf(event.message);
+        const matched = tail.findIndex(
+          (message) => message.role === 'user' && textOf(message) === deliveredText
+        );
+        if (matched !== -1) tail = tail.toSpliced(matched, 1);
+      }
+      return { ...current, messages: [...authoritative, ...tail], lastSeq: event.seq };
     }
     case 'approval-request':
       return {


### PR DESCRIPTION
## 现象

agent 跑工具时把消息入队并点「立即发送」：消息上屏后凭空消失，前面轮次跑完又重新出现。

## 根因：索引碰撞

乐观回显放在本地 messages 尾部 `index L`；steer 的语义是「下一个循环边界注入」（**不打断进行中的 tool**），期间当前轮的 assistant/tool 消息继续以 `index L` 发 `message-upsert`，reducer 的 `messages[index] = message` 直接把回显顶掉。轮次推进后 worker 才为这条 user 消息发真正的 upsert → 重新出现。

## 修法：浮动尾巴

- 乐观消息带 `optimistic` 标记；reducer 把 messages 分为**权威区 + 乐观尾巴**：权威 upsert 只写权威区，尾巴永远浮在其后
- 同文本的 user upsert 到达 = 回显对应的真消息落地，消费掉尾巴项避免重复
- sendMessage / flushQueue / sendQueuedNow / goal kickoff 四处回显统一打标（不再依赖「同 index 覆盖对齐」这个脆弱假设）

## 验证

- 回归测试（反向验证过）：assistant upsert 撞 index 时回显浮到其后；同文本 user upsert 消费尾巴；历史区就地覆盖不受影响
- 真机（fake provider + `sleep 15` 工具）：插队消息 12s 逐秒采样全程在场，轮次结束无重复，optimistic 归零
- typecheck 干净 / 86 文件 692 测试全绿