### PR TITLE
fix: @ 弹层 hover 与键盘导航打架 + enso-cdp skill 脚本沉淀

### DIFF
--- a/.agents/skills/enso-cdp/SKILL.md
+++ b/.agents/skills/enso-cdp/SKILL.md
@@ -11,7 +11,33 @@ description: >
 
 Dev (`!app.isPackaged`) already opens **9222** in `src/main/index.ts`. Do not inject `TEMP-DEBUG`. Packaged builds stay closed.
 
-## Connect
+## Scripts first
+
+免依赖脚本在 `scripts/`（相对本 skill 目录），优先用它们，不要重写 connect 样板：
+
+```bash
+node scripts/cdp.mjs pages                          # 列出 page 目标
+node scripts/cdp.mjs eval '(async()=>{...})()'      # 主窗口执行 JS（支持 await）
+node scripts/cdp.mjs eval '...' --page settings.html # 设置窗口
+node scripts/cdp.mjs shot /tmp/x.png                # 截图
+node scripts/cdp.mjs keys ArrowDown Enter           # 受信任按键（真实输入管线）
+node scripts/cdp.mjs type '@rev'                    # 受信任文本输入
+```
+
+合成事件（eval 里 dispatchEvent）`isTrusted=false` 且不过 IME/焦点管线；排查“真实键盘行为”用 `keys`/`type`。
+
+隔离验证环境（不碰真实 userData）：
+
+```bash
+node scripts/mk-env.mjs /tmp/enso-x 2      # 2 个 fake provider（凭证尾号可区分）
+node <repo>/scripts/fake-provider-issue-27.mjs &   # 8899；支持 [[tool:name {json}]] 指令
+ENSO_USER_DATA_DIR=/tmp/enso-x pnpm dev
+curl -s http://127.0.0.1:8899/__requests   # 每个请求实际带的凭证尾号
+```
+
+常用 store 入口（eval 里）：`window.__stores.sessions.getState()` / `window.__stores.settings.getState()`；`window.electronAPI.*` 是 preload API。
+
+## Connect（手写时才看）
 
 1. `pnpm dev` is running.
 2. `curl -s http://127.0.0.1:9222/json/version` — if this fails, restart dev (port is not HMR).

--- a/.agents/skills/enso-cdp/scripts/cdp.mjs
+++ b/.agents/skills/enso-cdp/scripts/cdp.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// EnsoCode CDP 驱动脚本（免依赖，node >= 22）。用法：
+//   node cdp.mjs pages                          列出可连接的 page 目标
+//   node cdp.mjs eval '<js>' [--page settings]  在页面里执行 JS（支持 await/Promise）
+//   node cdp.mjs shot /tmp/x.png [--page ...]   截图存文件
+//   node cdp.mjs keys ArrowDown ArrowDown Enter 受信任按键（走浏览器真实输入管线）
+//   node cdp.mjs type '@rev'                    受信任文本输入（Input.insertText）
+// --page 匹配 URL 子串，缺省 index.html（主窗口）；设置窗口用 --page settings.html。
+//
+// 何时用 keys/type 而非 eval 里的合成事件：合成 KeyboardEvent 的 isTrusted=false，
+// 且不经过 IME/焦点管线；排查"真实键盘行为"必须用受信任事件。
+
+const args = process.argv.slice(2);
+const cmd = args[0];
+const pageFlag = args.indexOf('--page');
+const urlFilter = pageFlag !== -1 ? args[pageFlag + 1] : 'index.html';
+const rest = (pageFlag !== -1 ? args.slice(0, pageFlag) : args).slice(1);
+
+if (!cmd || !['pages', 'eval', 'shot', 'keys', 'type'].includes(cmd)) {
+  console.error('usage: cdp.mjs pages|eval|shot|keys|type ... [--page <urlSubstring>]');
+  process.exit(2);
+}
+
+const list = await (await fetch('http://127.0.0.1:9222/json/list')).json().catch(() => null);
+if (!list) {
+  console.error('CDP 不可达：确认 pnpm dev 在跑（9222 不是 HMR，改了 main/agent 要重启）');
+  process.exit(2);
+}
+if (cmd === 'pages') {
+  for (const t of list.filter((x) => x.type === 'page')) console.log(t.url);
+  process.exit(0);
+}
+const page = list.find((x) => x.type === 'page' && x.url.includes(urlFilter));
+if (!page) {
+  console.error(`NO_PAGE for "${urlFilter}"，可用：`);
+  for (const t of list.filter((x) => x.type === 'page')) console.error(' ', t.url);
+  process.exit(2);
+}
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+let id = 0;
+const pending = new Map();
+ws.onmessage = (ev) => {
+  const m = JSON.parse(ev.data);
+  if (m.id && pending.has(m.id)) {
+    pending.get(m.id)(m);
+    pending.delete(m.id);
+  }
+};
+const send = (method, params = {}) =>
+  new Promise((res) => {
+    const i = ++id;
+    pending.set(i, res);
+    ws.send(JSON.stringify({ id: i, method, params }));
+  });
+await new Promise((res, rej) => {
+  ws.onopen = res;
+  ws.onerror = rej;
+});
+
+try {
+  if (cmd === 'eval') {
+    await send('Runtime.enable');
+    const r = await send('Runtime.evaluate', {
+      expression: rest[0],
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    if (r.result?.exceptionDetails) {
+      console.error('EXC', JSON.stringify(r.result.exceptionDetails).slice(0, 2000));
+      process.exit(1);
+    }
+    const v = r.result?.result?.value;
+    console.log(typeof v === 'string' ? v : JSON.stringify(v));
+  } else if (cmd === 'shot') {
+    const out = rest[0] || '/tmp/enso-shot.png';
+    const shot = await send('Page.captureScreenshot', { format: 'png' });
+    const { writeFileSync } = await import('node:fs');
+    writeFileSync(out, Buffer.from(shot.result.data, 'base64'));
+    console.log(out);
+  } else if (cmd === 'keys') {
+    // 常用键的 keyCode 映射；其余按 key 名直接发（现代前端多读 event.key）
+    const CODES = {
+      ArrowDown: 40,
+      ArrowUp: 38,
+      ArrowLeft: 37,
+      ArrowRight: 39,
+      Enter: 13,
+      Escape: 27,
+      Tab: 9,
+      Backspace: 8,
+    };
+    for (const key of rest) {
+      const keyCode = CODES[key];
+      const base = {
+        key,
+        code: key,
+        ...(keyCode ? { windowsVirtualKeyCode: keyCode, nativeVirtualKeyCode: keyCode } : {}),
+      };
+      await send('Input.dispatchKeyEvent', { type: 'rawKeyDown', ...base });
+      await send('Input.dispatchKeyEvent', { type: 'keyUp', ...base });
+      await new Promise((r) => setTimeout(r, 120));
+    }
+    console.log('sent:', rest.join(' '));
+  } else if (cmd === 'type') {
+    await send('Input.insertText', { text: rest[0] ?? '' });
+    console.log('typed');
+  }
+} finally {
+  ws.close();
+}

--- a/.agents/skills/enso-cdp/scripts/mk-env.mjs
+++ b/.agents/skills/enso-cdp/scripts/mk-env.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// 搭建隔离验证环境（不碰真实 userData）。用法：
+//   node mk-env.mjs /tmp/enso-x [providerCount]
+// 产出：
+//   /tmp/enso-x/settings.json    pv-A[/pv-B...] 指向 127.0.0.1:8899 的 fake provider
+//   /tmp/enso-x-proj/            空项目目录（含 README.md）
+// 配套：
+//   node scripts/fake-provider-issue-27.mjs   # 仓库根目录，起 8899 fake provider
+//   ENSO_USER_DATA_DIR=/tmp/enso-x pnpm dev
+// fake provider 支持 [[tool:name {json}]] 指令触发 tool_use；
+// /__requests 可查每个请求实际带的凭证尾号（区分 provider 铁证）。
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+
+const dir = process.argv[2];
+if (!dir || !dir.startsWith('/tmp/')) {
+  console.error('usage: mk-env.mjs /tmp/<name> [providerCount=1]  （强制 /tmp 前缀，防误伤真实数据）');
+  process.exit(2);
+}
+const count = Math.max(1, Math.min(4, Number(process.argv[3]) || 1));
+
+const providers = Array.from({ length: count }, (_, i) => {
+  const letter = String.fromCharCode(65 + i); // A, B, ...
+  return {
+    id: `pv-${letter}`,
+    name: `Provider ${letter}`,
+    api: 'anthropic-messages',
+    apiKey: `sk-fake-${letter}`,
+    baseUrl: 'http://127.0.0.1:8899',
+    enabled: true,
+    models: [{ id: 'fake-model-1' }],
+  };
+});
+
+const state = {
+  providers,
+  defaultModel: { providerId: 'pv-A', modelId: 'fake-model-1' },
+  onboarded: true,
+  theme: 'system',
+  language: 'zh-CN',
+};
+
+mkdirSync(dir, { recursive: true });
+writeFileSync(`${dir}/settings.json`, JSON.stringify({ 'enso-settings': { state, version: 2 } }));
+mkdirSync(`${dir}-proj`, { recursive: true });
+writeFileSync(`${dir}-proj/README.md`, 'isolated test project\n');
+console.log(`ok: ${dir} (${count} providers) + ${dir}-proj`);
+console.log(`next: node scripts/fake-provider-issue-27.mjs &`);
+console.log(`      ENSO_USER_DATA_DIR=${dir} pnpm dev`);

--- a/src/renderer/components/chat/Composer.tsx
+++ b/src/renderer/components/chat/Composer.tsx
@@ -379,7 +379,7 @@ export function Composer({
                 replaceToken('/', '');
                 setSlash(item.name);
               }}
-              onMouseEnter={() => setActiveIndex(index)}
+              onMouseMove={() => setActiveIndex(index)}
               className={cn(
                 'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs',
                 // 同 MentionPicker：浅色主题下 bg-muted 在纯白 popover 上不可见

--- a/src/renderer/components/chat/MentionPicker.tsx
+++ b/src/renderer/components/chat/MentionPicker.tsx
@@ -56,7 +56,7 @@ export function MentionPicker({
                 id={`${id}-option-${index}`}
                 candidate={candidate}
                 active={index === activeIndex}
-                onMouseEnter={() => onActiveIndexChange(index)}
+                onHover={() => onActiveIndexChange(index)}
                 onSelect={() => onSelect(candidate)}
               />
             );
@@ -80,7 +80,7 @@ export function MentionPicker({
                 id={`${id}-option-${index}`}
                 candidate={candidate}
                 active={index === activeIndex}
-                onMouseEnter={() => onActiveIndexChange(index)}
+                onHover={() => onActiveIndexChange(index)}
                 onSelect={() => onSelect(candidate)}
               />
             );
@@ -96,14 +96,14 @@ function MentionOption({
   id,
   candidate,
   active,
-  onMouseEnter,
+  onHover,
   onSelect,
 }: {
   id: string;
   ref: React.Ref<HTMLButtonElement>;
   candidate: MentionCandidate;
   active: boolean;
-  onMouseEnter: () => void;
+  onHover: () => void;
   onSelect: () => void;
 }) {
   const { t } = useI18n();
@@ -116,7 +116,10 @@ function MentionOption({
       role="option"
       aria-selected={active}
       onClick={onSelect}
-      onMouseEnter={onMouseEnter}
+      // onMouseMove 而非 onMouseEnter：键盘导航的 scrollIntoView 会让项目从静止的
+      // 物理光标下滑过，Chrome 重算 hover 触发 mouseenter 会把高亮拽回光标处；
+      // mousemove 只在物理移动时触发，不和键盘打架。
+      onMouseMove={onHover}
       className={cn(
         'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs',
         // 浅色主题下 popover(纯白)与 muted 亮度差仅 0.035，高亮几乎不可见；


### PR DESCRIPTION
## fix: 键盘导航被静止的物理光标打架（`d034750`)

键盘导航触发 scrollIntoView 时，列表项从**静止的物理光标**下滑过，Chrome 重算 hover 触发 mouseenter，把 activeIndex 拽回光标处——按上下键高亮乱跳。合成光标复现不了（CDP 合成位置不参与滚动 hover 重算），真实光标可复现，所以之前的自动化测试全绿而实际有问题。

`onMouseEnter` → `onMouseMove`（只在物理移动时触发，内容滚过静止光标不触发；Radix/cmdk 同款解法）。@ 弹层与 slash 列表同步改。

## chore: enso-cdp skill 沉淀免依赖脚本（`e4a33eb`)

- `scripts/cdp.mjs`：pages / eval / shot / keys / type 五个子命令，keys/type 走受信任输入管线
- `scripts/mk-env.mjs`：隔离验证环境脚手架（强制 /tmp 前缀）
- SKILL.md 脚本优先

全部命令真机跑通；typecheck 干净，692 测试全绿。