### PR TITLE
chore: 清掉 biome 全仓报错

### DIFF
--- a/scripts/cdp-issue-8-select-labels.mjs
+++ b/scripts/cdp-issue-8-select-labels.mjs
@@ -220,13 +220,15 @@ async function main() {
     screenshots: { mcpShot, providerShot },
     assertions: {
       mcpTransportIsHttp: mcpSelects.some((s) => s.valueSlot === 'http' || s.text.includes('http')),
-      apiTypeIsAnthropic: providerSelects.some((s) =>
-        (s.valueSlot === 'Anthropic' || s.text.includes('Anthropic')) &&
-        !s.valueSlot.includes('anthropic-messages')
+      apiTypeIsAnthropic: providerSelects.some(
+        (s) =>
+          (s.valueSlot === 'Anthropic' || s.text.includes('Anthropic')) &&
+          !s.valueSlot.includes('anthropic-messages')
       ),
-      testModelIsFriendlyLabel: providerSelects.some((s) =>
-        (s.valueSlot === 'Claude Sonnet 4' || s.text.includes('Claude Sonnet 4')) &&
-        !s.valueSlot.includes('claude-sonnet-4')
+      testModelIsFriendlyLabel: providerSelects.some(
+        (s) =>
+          (s.valueSlot === 'Claude Sonnet 4' || s.text.includes('Claude Sonnet 4')) &&
+          !s.valueSlot.includes('claude-sonnet-4')
       ),
     },
   };

--- a/src/agent/backgroundTasks.ts
+++ b/src/agent/backgroundTasks.ts
@@ -210,7 +210,7 @@ export class BackgroundTaskManager {
   /** 终止：SIGTERM 整个进程组，宽限后 SIGKILL */
   stop(taskId: string, byUser = false): boolean {
     const task = this.tasks.get(taskId);
-    if (!task || task.info.status !== 'running') return false;
+    if (task?.info.status !== 'running') return false;
     if (byUser) task.killedByUser = true;
     else task.consumed = true; // 模型自己停的：kill 回执即知情，不再通知
     const pid = task.child.pid;

--- a/src/main/services/nodeStore.ts
+++ b/src/main/services/nodeStore.ts
@@ -55,10 +55,7 @@ export function upsertNode(
     );
   }
   const trimmed = label?.trim();
-  return [
-    ...list,
-    { ...device, nodeId: device.pairId, label: trimmed || defaultLabel(list) },
-  ];
+  return [...list, { ...device, nodeId: device.pairId, label: trimmed || defaultLabel(list) }];
 }
 
 /**

--- a/src/main/services/pairGuest.ts
+++ b/src/main/services/pairGuest.ts
@@ -154,7 +154,11 @@ export async function pairNode(inviteUri: string): Promise<NodePairResult> {
     const detail = error instanceof Error ? error.message : String(error);
     // postJson 对 4xx 直接抛业务错误（如已被认领/过期），网络失败抛 fetch 错误
     const businessReject = /relay 4\d\d|not found|expired|claimed|authorized/i.test(detail);
-    return { ok: false, error: businessReject ? 'expired-or-claimed' : 'relay-unreachable', detail };
+    return {
+      ok: false,
+      error: businessReject ? 'expired-or-claimed' : 'relay-unreachable',
+      detail,
+    };
   }
   const device: PairedDevice = {
     pairId: claimed.pairId,

--- a/src/main/services/sshConnectionStore.test.ts
+++ b/src/main/services/sshConnectionStore.test.ts
@@ -51,15 +51,11 @@ describe('SshConnectionStore', () => {
 
   it('钥匙串不可用时拒绝保存密码连接', () => {
     const s = store(false);
-    expect(
-      s.upsert({ name: 'box', host: 'dev', auth: 'password', password: 'x' })
-    ).toEqual({
+    expect(s.upsert({ name: 'box', host: 'dev', auth: 'password', password: 'x' })).toEqual({
       ok: false,
       error: '无法加密保存密码:系统钥匙串不可用。',
     });
-    expect(
-      s.upsert({ name: 'key', host: 'dev', auth: 'key' }).ok
-    ).toBe(true);
+    expect(s.upsert({ name: 'key', host: 'dev', auth: 'key' }).ok).toBe(true);
   });
 
   it('改名可不重输密码;删除后口令消失', () => {

--- a/src/main/services/titleSummary.test.ts
+++ b/src/main/services/titleSummary.test.ts
@@ -79,9 +79,7 @@ describe('titleModelCandidates：标题模型 → 全局默认 → 会话模型�
       { providerId: 'default-p', modelId: 'default-m' },
       { providerId: 'session-p', modelId: 'session-m' },
     ]);
-    expect(
-      titleModelCandidates(state(), { providerId: 'title-p', modelId: 'title-m' })
-    ).toEqual([
+    expect(titleModelCandidates(state(), { providerId: 'title-p', modelId: 'title-m' })).toEqual([
       { providerId: 'title-p', modelId: 'title-m' },
       { providerId: 'default-p', modelId: 'default-m' },
     ]);

--- a/src/renderer/components/chat/ConversationTitleEdit.tsx
+++ b/src/renderer/components/chat/ConversationTitleEdit.tsx
@@ -26,6 +26,7 @@ export function ConversationTitleEdit({
         className
       )}
       value={draft}
+      // biome-ignore lint/a11y/noAutofocus: 进入编辑态必须立刻聚焦才能改标题
       autoFocus
       onChange={(e) => setDraft(e.target.value)}
       onBlur={commit}

--- a/src/renderer/components/chat/MentionEditor.tsx
+++ b/src/renderer/components/chat/MentionEditor.tsx
@@ -480,10 +480,10 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     );
 
     return (
+      // biome-ignore lint/a11y/useAriaPropsSupportedByRole: contentEditable 输入必须是 textbox，aria-placeholder 无原生等价
       <div
         ref={rootRef}
         contentEditable={!disabled}
-        // biome-ignore lint/a11y/useSemanticElements: contentEditable 富文本输入没有语义等价元素
         role={ariaProps?.role ?? 'textbox'}
         aria-placeholder={placeholder}
         data-placeholder={placeholder}

--- a/src/renderer/components/chat/MermaidRenderer.tsx
+++ b/src/renderer/components/chat/MermaidRenderer.tsx
@@ -209,10 +209,9 @@ export function MermaidRenderer({
   );
 
   const handleMouseUp = useCallback(() => setIsDragging(false), []);
-  const handleFullscreenContentClick = useCallback(
-    (e: React.MouseEvent) => e.stopPropagation(),
-    []
-  );
+  const handleFullscreenContentClick = useCallback((e: React.SyntheticEvent) => {
+    e.stopPropagation();
+  }, []);
   const handleFullscreenOverlayClick = useCallback(() => {
     if (!hasDraggedRef.current) handleExitFullscreen();
   }, [handleExitFullscreen]);
@@ -368,10 +367,14 @@ export function MermaidRenderer({
           style={{ zIndex: Z_INDEX.TOAST }}
           data-enso-float=""
           onClick={handleFullscreenOverlayClick}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') handleExitFullscreen();
+          }}
         >
           <div
             className="flex shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4 py-2"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
           >
             <span className="text-sm font-medium text-muted-foreground">
               {t('Mermaid preview')}
@@ -399,6 +402,7 @@ export function MermaidRenderer({
               onMouseUp={handleMouseUp}
               onMouseLeave={handleMouseUp}
               onClick={handleFullscreenContentClick}
+              onKeyDown={handleFullscreenContentClick}
             >
               <div
                 className="origin-center transition-transform duration-100 ease-out"

--- a/src/renderer/components/chat/chatSearch.ts
+++ b/src/renderer/components/chat/chatSearch.ts
@@ -20,10 +20,12 @@ export function timelineSearchHits(items: readonly TimelineItem[], query: string
     const hay = item.text.toLowerCase();
     let from = 0;
     let nth = 0;
-    while ((from = hay.indexOf(q, from)) !== -1) {
+    for (;;) {
+      const at = hay.indexOf(q, from);
+      if (at === -1) break;
       hits.push({ key: item.key, nth });
       nth += 1;
-      from += q.length;
+      from = at + q.length;
     }
   }
   return hits;

--- a/src/renderer/components/chat/highlightQuery.tsx
+++ b/src/renderer/components/chat/highlightQuery.tsx
@@ -55,6 +55,7 @@ export function highlightNode(
   }
   if (Array.isArray(node)) {
     return node.map((child, index) => (
+      // biome-ignore lint/suspicious/noArrayIndexKey: 混合 ReactNode 没有稳定 identity
       <Fragment key={index}>{highlightNode(child, query, activeNth, counter)}</Fragment>
     ));
   }

--- a/src/renderer/components/nodes/PairNodeDialog.tsx
+++ b/src/renderer/components/nodes/PairNodeDialog.tsx
@@ -30,7 +30,11 @@ const ERROR_KEYS: Record<NodePairError, string> = {
 };
 
 /** 粘贴另一台桌面「设置 → 设备」里复制的配对链接，认领后进入其房间 */
-export function PairNodeDialog({ open, onOpenChange, switchOnSuccess = true }: PairNodeDialogProps) {
+export function PairNodeDialog({
+  open,
+  onOpenChange,
+  switchOnSuccess = true,
+}: PairNodeDialogProps) {
   const { t } = useI18n();
   const [uri, setUri] = useState('');
   const [busy, setBusy] = useState(false);

--- a/src/renderer/components/nodes/RemoteNodeChat.tsx
+++ b/src/renderer/components/nodes/RemoteNodeChat.tsx
@@ -87,10 +87,7 @@ export function RemoteNodeChat(props: RemoteNodeChatProps) {
     if (timelineRef.current?.isAtBottom()) timelineRef.current.pinToBottom();
   }, [timeline]);
 
-  const host = useMemo(
-    () => ({ sessionId, canRewind: false, canRetry: false }),
-    [sessionId]
-  );
+  const host = useMemo(() => ({ sessionId, canRewind: false, canRetry: false }), [sessionId]);
   const providers = useMemo(() => toModelProviders(props.providers), [props.providers]);
   const configurable = entry && !entry.parentId;
 
@@ -112,7 +109,9 @@ export function RemoteNodeChat(props: RemoteNodeChatProps) {
           {entry && (
             <>
               <span className="text-muted-foreground/50">/</span>
-              <span className="min-w-0 truncate text-sm">{entry.title || t('New conversation')}</span>
+              <span className="min-w-0 truncate text-sm">
+                {entry.title || t('New conversation')}
+              </span>
               {entry.projectName && (
                 <span className="truncate font-mono text-muted-foreground text-xs">
                   {entry.projectName}

--- a/src/renderer/components/nodes/RemoteNodeSidebar.tsx
+++ b/src/renderer/components/nodes/RemoteNodeSidebar.tsx
@@ -1,9 +1,5 @@
 import type { CatalogEntry, ProjectEntry } from '@enso/pair';
-import {
-  orderPinned,
-  orderProjectSessions,
-  sortByActivity,
-} from '@shared/pair/drawerOrder';
+import { orderPinned, orderProjectSessions, sortByActivity } from '@shared/pair/drawerOrder';
 import type { RemoteNodeStatus } from '@shared/types/nodes';
 import { Archive, ChevronDown, ChevronRight, Pin, Search, SquarePen } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';

--- a/src/renderer/components/nodes/RemoteNodeView.tsx
+++ b/src/renderer/components/nodes/RemoteNodeView.tsx
@@ -35,7 +35,9 @@ export function RemoteNodeView({ nodeId, sidebarWidth }: RemoteNodeViewProps) {
     return children.length > 0 ? { parent, children } : undefined;
   }, [view.catalog, entry]);
   const session = activeId ? (view.sessions[activeId] ?? null) : null;
-  const hasOlder = Boolean(session && session.messages.size > 0 && Math.min(...session.messages.keys()) > 0);
+  const hasOlder = Boolean(
+    session && session.messages.size > 0 && Math.min(...session.messages.keys()) > 0
+  );
 
   if (!node) return null;
 

--- a/src/renderer/components/sidepanel/FilesView.tsx
+++ b/src/renderer/components/sidepanel/FilesView.tsx
@@ -384,7 +384,8 @@ export function FilesView({ conversationId, projectId }: FilesViewProps) {
                           const keep = doc.rel;
                           const dirtyOthers = docs.some((item) => item.rel !== keep && item.dirty);
                           closeRels(
-                            (path) => path !== keep && !docs.find((item) => item.rel === path)?.dirty
+                            (path) =>
+                              path !== keep && !docs.find((item) => item.rel === path)?.dirty
                           );
                           if (dirtyOthers) setConfirmClose({ kind: 'others', rel: keep });
                         }}

--- a/src/renderer/stores/sessions/timeline.ts
+++ b/src/renderer/stores/sessions/timeline.ts
@@ -606,11 +606,19 @@ function firstProgram(segment: string): string {
  * 只影响展示密度，不参与审批；策略保守：重定向、命令/进程替换、后台 &、写参数、
  * 未知程序、GIT_* 环境前缀（GIT_EXTERNAL_DIFF 等会转执行）一律判非只读。
  */
+function hasC0Control(text: string): boolean {
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code <= 0x1f && code !== 0x0a) return true;
+  }
+  return false;
+}
+
 export function isReadOnlyCommand(command: string): boolean {
   const trimmed = command.trim();
   if (!trimmed) return false;
   // 命令替换 / 进程替换 / 反引号可藏任意命令；控制字符（\r 等）可拼接隐藏命令
-  if (/\$\(|<\(|`|[\x00-\x09\x0b-\x1f]/.test(trimmed)) return false;
+  if (/\$\(|<\(|`/.test(trimmed) || hasC0Control(trimmed)) return false;
   // 去掉无害的 stderr 重定向后，剩余任何 > 都视为写文件
   const withoutStderr = trimmed.replace(/2>&1|[12]?>\s*\/dev\/null/g, '');
   if (withoutStderr.includes('>')) return false;

--- a/src/shared/browser/designMode.test.ts
+++ b/src/shared/browser/designMode.test.ts
@@ -86,7 +86,7 @@ describe('sanitizeUiElementPayload', () => {
 
   it('脏输入：缺字段补空串、非字符串丢弃、超长截断、危险字符净化', () => {
     const out = sanitizeUiElementPayload({
-      label: 'B'.repeat(100) + '"[]\n',
+      label: `${'B'.repeat(100)}"[]\n`,
       path: 123,
       text: 'T'.repeat(300),
       tag: 'button',


### PR DESCRIPTION
Follow-up after merging #39 and #40. `pnpm lint` now exits 0 (only the biome.json `recommended` deprecation info remains).