### PR TITLE
fix(usage): 每日趋势默认不叠缓存，输出才看得见

### DIFF
--- a/src/renderer/components/settings/usage/DailyTrendChart.tsx
+++ b/src/renderer/components/settings/usage/DailyTrendChart.tsx
@@ -31,11 +31,10 @@ export function DailyTrendChart({ daily }: { daily: UsageDailyPoint[] }) {
   const { t } = useI18n();
   const [metric, setMetric] = React.useState<Metric>('tokens');
   const [hover, setHover] = React.useState<number | null>(null);
-  // 缓存默认关：量级通常比输出大两个数量级，叠在一起输出看不见
   const [on, setOn] = React.useState<Record<SeriesId, boolean>>({
     output: true,
     input: true,
-    cache: false,
+    cache: true,
   });
 
   const toggle = (id: SeriesId) => {

--- a/src/renderer/components/settings/usage/DailyTrendChart.tsx
+++ b/src/renderer/components/settings/usage/DailyTrendChart.tsx
@@ -5,36 +5,58 @@ import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
 
 type Metric = 'tokens' | 'cost';
+type SeriesId = 'output' | 'input' | 'cache';
 
 const W = 640;
 const H = 180;
 const PAD_TOP = 8;
 const PAD_BOTTOM = 18;
 const GAP_RATIO = 0.3;
+/** 非零段至少 2px，避免输出相对缓存小两个数量级时被线性坐标压没 */
+const MIN_SEG_PX = 2;
 
 function dayLabel(day: string): string {
   const [, m, d] = day.split('-');
   return `${Number(m)}/${Number(d)}`;
 }
 
-/** 每日趋势：Token 模式堆叠 输出/输入/缓存 三段；费用模式单柱。纯 SVG，随容器宽度缩放。 */
+const TOKEN_SERIES: Array<{ id: SeriesId; cls: string; swatch: string }> = [
+  { id: 'cache', cls: 'fill-foreground/15', swatch: 'bg-foreground/15' },
+  { id: 'input', cls: 'fill-foreground/45', swatch: 'bg-foreground/45' },
+  { id: 'output', cls: 'fill-foreground', swatch: 'bg-foreground' },
+];
+
+/** 每日趋势：Token 模式堆叠 输出/输入/缓存；费用模式单柱。图例可点选系列。 */
 export function DailyTrendChart({ daily }: { daily: UsageDailyPoint[] }) {
   const { t } = useI18n();
   const [metric, setMetric] = React.useState<Metric>('tokens');
   const [hover, setHover] = React.useState<number | null>(null);
+  // 缓存默认关：量级通常比输出大两个数量级，叠在一起输出看不见
+  const [on, setOn] = React.useState<Record<SeriesId, boolean>>({
+    output: true,
+    input: true,
+    cache: false,
+  });
 
-  const values = daily.map((p) =>
-    metric === 'tokens' ? p.input + p.output + p.cache : (p.cost ?? 0)
-  );
+  const toggle = (id: SeriesId) => {
+    setOn((prev) => {
+      const next = { ...prev, [id]: !prev[id] };
+      if (!next.output && !next.input && !next.cache) return prev;
+      return next;
+    });
+  };
+
+  const values = daily.map((p) => {
+    if (metric === 'cost') return p.cost ?? 0;
+    return (on.output ? p.output : 0) + (on.input ? p.input : 0) + (on.cache ? p.cache : 0);
+  });
   const max = Math.max(0, ...values);
   const n = Math.max(1, daily.length);
   const slot = W / n;
-  // 单日视图不要拉成一整块色块
   const barW = Math.min(slot * (1 - GAP_RATIO), 64);
   const plotH = H - PAD_TOP - PAD_BOTTOM;
   const scale = (v: number) => (max > 0 ? (v / max) * plotH : 0);
 
-  // 横轴标签最多 ~12 个，避免 90 天时挤成一团
   const labelEvery = Math.max(1, Math.ceil(n / 12));
   const hovered = hover !== null ? daily[hover] : null;
 
@@ -45,9 +67,24 @@ export function DailyTrendChart({ daily }: { daily: UsageDailyPoint[] }) {
         <div className="flex items-center gap-3">
           {metric === 'tokens' && (
             <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
-              <Legend className="bg-foreground" label={t('Output')} />
-              <Legend className="bg-foreground/45" label={t('Input')} />
-              <Legend className="bg-foreground/15" label={t('Cache')} />
+              <Legend
+                className="bg-foreground"
+                label={t('Output')}
+                pressed={on.output}
+                onClick={() => toggle('output')}
+              />
+              <Legend
+                className="bg-foreground/45"
+                label={t('Input')}
+                pressed={on.input}
+                onClick={() => toggle('input')}
+              />
+              <Legend
+                className="bg-foreground/15"
+                label={t('Cache')}
+                pressed={on.cache}
+                onClick={() => toggle('cache')}
+              />
             </div>
           )}
           <MetricToggle value={metric} onChange={setMetric} />
@@ -59,8 +96,22 @@ export function DailyTrendChart({ daily }: { daily: UsageDailyPoint[] }) {
         </div>
         {hovered && (
           <div className="pointer-events-none absolute right-0 top-0 rounded bg-popover px-2 py-1 font-mono text-[11px] text-popover-foreground shadow-sm ring-1 ring-border">
-            {hovered.day} ·{' '}
-            {metric === 'tokens' ? formatTokens(values[hover ?? 0] ?? 0) : formatCost(hovered.cost)}
+            {hovered.day}
+            {metric === 'tokens' ? (
+              <>
+                <div>
+                  {t('Output')} {formatTokens(hovered.output)}
+                </div>
+                <div>
+                  {t('Input')} {formatTokens(hovered.input)}
+                </div>
+                <div>
+                  {t('Cache')} {formatTokens(hovered.cache)}
+                </div>
+              </>
+            ) : (
+              <> · {formatCost(hovered.cost)}</>
+            )}
           </div>
         )}
         <svg
@@ -75,18 +126,17 @@ export function DailyTrendChart({ daily }: { daily: UsageDailyPoint[] }) {
             const base = H - PAD_BOTTOM;
             const segments =
               metric === 'tokens'
-                ? [
-                    { v: p.cache, cls: 'fill-foreground/15' },
-                    { v: p.input, cls: 'fill-foreground/45' },
-                    { v: p.output, cls: 'fill-foreground' },
-                  ]
+                ? TOKEN_SERIES.filter((s) => on[s.id]).map((s) => ({
+                    v: p[s.id],
+                    cls: s.cls,
+                  }))
                 : [{ v: p.cost ?? 0, cls: 'fill-emerald-600 dark:fill-emerald-500' }];
             let y = base;
             return (
               <g key={p.day} onMouseEnter={() => setHover(i)}>
                 <rect x={x} y={PAD_TOP} width={barW} height={plotH} className="fill-transparent" />
                 {segments.map((s) => {
-                  const h = scale(s.v);
+                  const h = s.v > 0 ? Math.max(MIN_SEG_PX, scale(s.v)) : 0;
                   y -= h;
                   return (
                     <rect
@@ -119,12 +169,30 @@ export function DailyTrendChart({ daily }: { daily: UsageDailyPoint[] }) {
   );
 }
 
-function Legend({ className, label }: { className: string; label: string }) {
+function Legend({
+  className,
+  label,
+  pressed,
+  onClick,
+}: {
+  className: string;
+  label: string;
+  pressed: boolean;
+  onClick: () => void;
+}) {
   return (
-    <span className="flex items-center gap-1">
+    <button
+      type="button"
+      aria-pressed={pressed}
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-1 rounded px-0.5 transition-opacity',
+        pressed ? 'opacity-100' : 'opacity-40'
+      )}
+    >
       <span className={cn('inline-block h-2.5 w-2.5 rounded-sm', className)} />
       {label}
-    </span>
+    </button>
   );
 }
 


### PR DESCRIPTION
截图里柱状图几乎只有输入和缓存：数据里输出是有的（大约是缓存的 0.4%），线性叠柱会被压成不到 1px。默认只画输出+输入，点图例「缓存」可加回来；悬停显示三段数字。