### PR TITLE
Windows 最大化后标题栏按钮切换为还原图标

### DIFF
--- a/.trellis/spec/main/windows.md
+++ b/.trellis/spec/main/windows.md
@@ -31,6 +31,7 @@ frame: isMac,
 ```
 
 macOS 保留系统红绿灯，Windows/Linux 由渲染层自绘（`components/app/TitleBar.tsx`）。
+最大化后中间按钮改成还原图标（重叠方块），不要一直画单个方块。
 
 Windows 透明主窗口无框后系统不再画圆角和外框。主窗口渲染层用
 `useWindowsWindowChrome` 给 `html` 挂 `enso-win`，`globals.css` 给 `#root`

--- a/src/renderer/components/app/TitleBar.tsx
+++ b/src/renderer/components/app/TitleBar.tsx
@@ -1,5 +1,6 @@
 import { ENSO_AGENT_TYPE_KEY } from '@shared/builtinAgents';
-import { Minus, Sparkles, Square, X } from 'lucide-react';
+import { Copy, Minus, Sparkles, Square, X } from 'lucide-react';
+import { useWindowMaximized } from '@/hooks/useWindowMaximized';
 import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
 
@@ -33,7 +34,9 @@ export function SummonEnsoButton({ label = true }: { label?: boolean }) {
  * - Windows/Linux: 自绘最小化/最大化/关闭按钮
  */
 export function TitleBar({ title, className, actions }: TitleBarProps) {
+  const { t } = useI18n();
   const isMac = window.electronAPI.env.platform === 'darwin';
+  const maximized = useWindowMaximized();
 
   return (
     <header
@@ -54,6 +57,8 @@ export function TitleBar({ title, className, actions }: TitleBarProps) {
             type="button"
             className="flex h-full w-12 items-center justify-center hover:bg-muted"
             onClick={() => window.electronAPI.window.minimize()}
+            aria-label={t('Minimize')}
+            title={t('Minimize')}
           >
             <Minus className="h-4 w-4" />
           </button>
@@ -61,13 +66,17 @@ export function TitleBar({ title, className, actions }: TitleBarProps) {
             type="button"
             className="flex h-full w-12 items-center justify-center hover:bg-muted"
             onClick={() => window.electronAPI.window.maximize()}
+            aria-label={maximized ? t('Restore') : t('Maximize')}
+            title={maximized ? t('Restore') : t('Maximize')}
           >
-            <Square className="h-3.5 w-3.5" />
+            {maximized ? <Copy className="h-3.5 w-3.5" /> : <Square className="h-3.5 w-3.5" />}
           </button>
           <button
             type="button"
             className="flex h-full w-12 items-center justify-center hover:bg-destructive hover:text-destructive-foreground"
             onClick={() => window.electronAPI.window.close()}
+            aria-label={t('Close')}
+            title={t('Close')}
           >
             <X className="h-4 w-4" />
           </button>

--- a/src/renderer/hooks/useWindowMaximized.ts
+++ b/src/renderer/hooks/useWindowMaximized.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Windows/Linux 自绘标题栏用：最大化后切还原图标。
+ * Windows 上 unmaximize 通知可能丢，resize 后重查 isMaximized。
+ */
+export function useWindowMaximized(): boolean {
+  const [maximized, setMaximized] = useState(false);
+
+  useEffect(() => {
+    const api = window.electronAPI?.window;
+    if (!api) return;
+
+    let disposed = false;
+    let queryRevision = 0;
+    let eventRevision = 0;
+    let resizeTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const query = () => {
+      const revision = ++queryRevision;
+      const eventRevisionAtQuery = eventRevision;
+      void api
+        .isMaximized()
+        .then((value) => {
+          if (disposed || revision !== queryRevision) return;
+          if (eventRevision !== eventRevisionAtQuery) return;
+          setMaximized(value);
+        })
+        .catch(() => {
+          // 窗口正在销毁时 IPC 可能失败
+        });
+    };
+    query();
+
+    const onResize = () => {
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(query, 50);
+    };
+    window.addEventListener('resize', onResize);
+
+    const offMaximized = api.onMaximizedChange((value) => {
+      eventRevision += 1;
+      setMaximized(value);
+    });
+
+    return () => {
+      disposed = true;
+      if (resizeTimer) clearTimeout(resizeTimer);
+      window.removeEventListener('resize', onResize);
+      offMaximized();
+    };
+  }, []);
+
+  return maximized;
+}

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -176,6 +176,9 @@ export const zhTranslations: Record<string, string> = {
   Next: '下一步',
   'Get started': '开始',
   Close: '关闭',
+  Minimize: '最小化',
+  Maximize: '最大化',
+  Restore: '还原',
   'No new providers imported': '没有新导入的模型服务',
   'Fetch models for each provider, then enable the ones you want.':
     '为每个模型服务拉取模型，再启用你需要的。',


### PR DESCRIPTION
Windows 无框窗口自绘标题栏在最大化后仍显示最大化图标。跟随窗口状态改为还原图标，并补上最小化/最大化/还原的无障碍标签。