### PR TITLE
fix(renderer): 合并会话持久化写入，修复流式更新 OOM

### DIFF
--- a/.trellis/spec/main/settings-persistence.md
+++ b/.trellis/spec/main/settings-persistence.md
@@ -141,3 +141,55 @@ useSettingsStore.setState({ projects: next });
 - 大段文本（指令文件内容）→ `userData/instructions/<id>.md`，
   settings 里只存元数据。理由：settings.json 每次设置变更都整体重写，
   塞进几十 KB 文本会让每次写入都变重。
+
+## 会话流式持久化的内存上限
+
+### 适用范围
+
+会话 store 每条流式事件都可能触发持久化。主进程的磁盘防抖发生在 IPC 收包之后，
+不能限制 renderer 的 JSON 编解码、contextBridge 复制及在途请求。大量重复 commands
+会放大每笔元数据，突发写入可造成 V8 OOM。设置 store 保留原来的字符串适配器。
+
+### 接口
+
+`stores/settings/storage.ts` 导出 `createElectronPersistStorage<State>(): PersistStorage<State>`，
+供会话 store 直接传入 `persist.storage`，不包 `createJSONStorage`。
+复用既有 `settings.writeKey(name, { state, version })`；删除传 `undefined`，不增加 IPC。
+
+### 契约
+
+- 每个适配器、每个键最多一个在途 IPC 和一个最新待写对象；第一笔立即发送，后续覆盖待写值。
+- 同一批次共享完成 Promise，不逐事件保存 payload 或 resolver 列表。
+- 删除与更新共同排序；最后操作决定最终值。不同键独立推进。
+- 水合前丢弃写入；接受后的每次更新均增加 `writeGeneration`，即使之后被合并。
+- `getItem` 等待同键在途批次完成后读取，防止主动 rehydrate 回退到旧值。
+- commands 不进入会话 partialize；旧数据可读，后续正常写入剥离，worker 继续恢复内存。
+
+### 错误与验证
+
+| 条件 | 行为 |
+| --- | --- |
+| 闸门关闭 | 直接丢弃，不排队、不增加写入代数 |
+| IPC 返回 false / 拒绝 / 同步抛错 | 批次 Promise 拒绝并报告错误，继续处理最新待写值，不锁死后续批次 |
+| 同键批次写入成功 | 完成 Promise 在最后值写完后解决 |
+
+### 场景
+
+正常：单次元数据更新立即发送；突发：首值在途时数百次更新合并为最新值；
+错误：把数百个完整会话副本各自发送，再指望主进程的磁盘 debounce 解决内存峰值。
+
+### 回归测试
+
+`settings/coalescedStorage.test.ts` 覆盖在途上限、最后值、共享 Promise、不同键隔离、
+更新/删除顺序、失败恢复、读写顺序和水合闸门；`sessions/index.test.ts` 覆盖冷事件
+不触发持久化、commands 恢复及投影。断言写入次数和最后值，不能只断言 UI state 正确。
+
+### 错误与正确接法
+
+```ts
+// 错误：每次 state 更新已经 stringify，排队时还会保留多份巨型字符串。
+storage: createJSONStorage(() => electronStorage)
+
+// 正确：会话在对象级合并，发送时才发生跨进程复制。
+storage: createElectronPersistStorage()
+```

--- a/.trellis/spec/renderer/state.md
+++ b/.trellis/spec/renderer/state.md
@@ -1,6 +1,6 @@
 # 状态管理规范
 
-两个主 store：持久化的 `stores/settings/` 与内存态的 `stores/sessions/`。右侧面板另有 `stores/sidePanel/`：dock 布局与各会话的开关/宽度 persist 到 localStorage，`fullscreen` 只活在内存里。
+两个主 store：设置持久化的 `stores/settings/` 与会话元数据持久化的 `stores/sessions/`。右侧面板另有 `stores/sidePanel/`：dock 布局与各会话的开关/宽度 persist 到 localStorage，`fullscreen` 只活在内存里。
 
 ```
 stores/settings/
@@ -9,10 +9,12 @@ stores/settings/
   index.ts     create + persist + 副作用
 stores/sessions/
   reducer.ts   applyAgentEvent：agent 事件 → 会话投影的纯函数（seq 单调守卫）
-  index.ts     create（不 persist）+ onAgentEvent 订阅 + spawn/send/abort
+  index.ts     create + 元数据 persist + onAgentEvent 订阅 + spawn/send/abort
 ```
 
-`sessions` 是**可丢弃投影**（权威源在 worker/jsonl），不 persist、不进 settings.json。
+`sessions` 的正文是**可丢弃投影**（权威源在 worker/jsonl）；会话元数据写入
+`settings.json` 的 `enso-conversations`。正文、customEntries 和可由 worker 重建的
+commands 不持久化，commands 仍由 snapshot / commands 事件恢复到内存。
 消息按 `message-upsert` 的 index 整条替换，**没有增量归并**；
 过期 seq 的事件在 reducer 里丢弃。改事件处理逻辑时改 `reducer.ts`（纯函数，有测试），
 不要把逻辑写进订阅回调。
@@ -104,12 +106,20 @@ expect(store.getState().conversations.ended.messages).toHaveLength(before);
 
 ## 持久化边界
 
-store 里的一切都会被写进 `settings.json`。因此：
+写入 `settings.json` 的内容由 persist 的 `partialize` 决定。因此：
 
 - **大段文本不要进 store** —— 指令文件内容存 `userData/instructions/<id>.md`，
   store 只留元数据（`name` / `sourcePath` / `local` / `bytes`）。
 - 临时 UI 状态（弹窗开合、筛选词、忙碌标记）用 `React.useState`，不要进 store。
 - 字段的兼容性约束见 [../shared/types.md](../shared/types.md) 的"持久化类型的演进"。
+
+高频会话事件使用 `createElectronPersistStorage()` 对象级入口，在 JSON 编解码和
+contextBridge 复制之前合并写入；不能在 `createJSONStorage` 后再排队字符串。
+同键最多一个在途写入及一个最新待写值。完整契约见
+[设置持久化规范](../main/settings-persistence.md#会话流式持久化的内存上限)。
+
+Zustand persist 即使收到 `set((state) => state)` 也会调用存储适配器。
+已知无需更新的后台事件应在调用 `set` 之前返回，保留无标题首条用户消息的标题提取。
 
 ## 多窗口同步
 

--- a/src/renderer/stores/sessions/index.test.ts
+++ b/src/renderer/stores/sessions/index.test.ts
@@ -259,6 +259,109 @@ describe('typed Agent child projection', () => {
     await seedParent();
   });
 
+  it('worker snapshot 恢复命令但会话持久化不保存命令列表', async () => {
+    const commands = [{ name: 'review', description: '检查当前改动' }];
+    onAgentEvent?.({
+      type: 'snapshot',
+      partial: true,
+      sessions: [
+        {
+          identity: { sessionId: 'parent', generation: 'command-generation' },
+          status: 'idle',
+          messages: [],
+          commands,
+        },
+      ],
+    });
+    expect(sessionsModule.useSessionsStore.getState().conversations.parent.commands).toEqual(
+      commands
+    );
+    const storage = sessionsModule.useSessionsStore.persist.getOptions().storage!;
+    await storage.getItem('enso-conversations');
+    const calls = vi.mocked(window.electronAPI.settings.writeKey).mock.calls;
+    const saved = calls.filter(([name]) => name === 'enso-conversations').at(-1)?.[1];
+    expect(saved).toMatchObject({ state: { conversations: { parent: { commands: [] } } } });
+  });
+
+  it('冷会话已有标题时连续后台消息不触发持久化', async () => {
+    const store = sessionsModule.useSessionsStore;
+    store.setState((state) => ({
+      conversations: {
+        ...state.conversations,
+        cold: { ...state.conversations.parent, id: 'cold', title: '后台会话' },
+      },
+    }));
+    const storage = store.persist.getOptions().storage!;
+    await storage.getItem('enso-conversations');
+    const write = vi.spyOn(storage, 'setItem');
+    const before = store.getState().conversations.cold;
+    for (let seq = 1; seq <= 100; seq++) {
+      onAgentEvent?.({
+        type: 'message-upsert',
+        identity: { sessionId: 'cold', generation: 'g1' },
+        seq,
+        index: 0,
+        message: { role: 'assistant', content: [{ type: 'text', text: `片段 ${seq}` }] },
+      });
+    }
+    expect(store.getState().conversations.cold).toBe(before);
+    expect(write.mock.calls.length).toBe(0);
+    write.mockRestore();
+  });
+
+  it('冷会话无标题时助手消息与空用户消息也不触发持久化', async () => {
+    const store = sessionsModule.useSessionsStore;
+    store.setState((state) => ({
+      conversations: {
+        ...state.conversations,
+        untitled: { ...state.conversations.parent, id: 'untitled', title: '' },
+      },
+    }));
+    const storage = store.persist.getOptions().storage!;
+    await storage.getItem('enso-conversations');
+    const write = vi.spyOn(storage, 'setItem');
+    for (const role of ['assistant', 'user'] as const) {
+      onAgentEvent?.({
+        type: 'message-upsert',
+        identity: { sessionId: 'untitled', generation: 'g1' },
+        seq: 1,
+        index: 0,
+        message: { role, content: [{ type: 'text', text: '' }] },
+      });
+    }
+    expect(write.mock.calls.length).toBe(0);
+    write.mockRestore();
+  });
+
+  it('会话 store 连续更新合并在 IPC 之前，并保存最终元数据', async () => {
+    const store = sessionsModule.useSessionsStore;
+    const storage = store.persist.getOptions().storage!;
+    await storage.getItem('enso-conversations');
+    const writeKey = vi.mocked(window.electronAPI.settings.writeKey);
+    writeKey.mockClear();
+    let finish!: (value: boolean) => void;
+    writeKey.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        finish = resolve;
+      })
+    );
+    for (let index = 0; index <= 600; index++) {
+      store.setState((state) => ({
+        conversations: {
+          ...state.conversations,
+          parent: { ...state.conversations.parent, title: `标题 ${index}` },
+        },
+      }));
+    }
+    expect(writeKey.mock.calls.length).toBe(1);
+    finish(true);
+    await storage.getItem('enso-conversations');
+    expect(writeKey.mock.calls.length).toBe(2);
+    expect(writeKey.mock.calls.at(-1)?.[1]).toMatchObject({
+      state: { conversations: { parent: { title: '标题 600' } } },
+    });
+  });
+
   it('parent-rejected clears started and lands failed so retry can spawn again', () => {
     // spawn IPC ack 后 store 乐观置 started:true；若 rejected 到达时不清回 false，
     // 重发会走 prompt 分支打到 worker 里不存在的会话，重试彻底无声。

--- a/src/renderer/stores/sessions/index.ts
+++ b/src/renderer/stores/sessions/index.ts
@@ -46,10 +46,10 @@ export interface QueuedMessage {
 
 import { projectSafeJournal } from '@shared/safeJournalProjection';
 import { create } from 'zustand';
-import { createJSONStorage, persist } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
 import { oauthCredentialContext, useOauthCredentialStore } from '@/stores/oauthCredentials';
 import { useSettingsStore } from '@/stores/settings';
-import { electronStorage, openPersistWriteGate } from '@/stores/settings/storage';
+import { createElectronPersistStorage, openPersistWriteGate } from '@/stores/settings/storage';
 import { purgeConversationAuthority } from './authorityCleanup';
 import {
   evictColdMessages,
@@ -913,37 +913,35 @@ export const useSessionsStore = create<SessionsState>()(
           return;
         }
 
+        const current = get();
+        const currentConversation = current.conversations[id];
+        if (!currentConversation) return;
+        // 手机创建的冷会话仍需从首条用户消息提取标题。
+        const rawUserText =
+          !currentConversation.title &&
+          event.type === 'message-upsert' &&
+          event.message.role === 'user'
+            ? userMessageRawText(event.message)
+            : undefined;
+        const extractedTitle = rawUserText ? truncateTitle(rawUserText) : undefined;
+        if (
+          isBulkyAgentEvent(event.type) &&
+          !isMessageCacheHot(id, viewedFromState(current), lastViewedAt, Date.now())
+        ) {
+          if (extractedTitle && rawUserText) {
+            trySummarizeTitle(id, rawUserText, extractedTitle, {
+              providerId: currentConversation.lastProviderId,
+              modelId: currentConversation.lastModelId,
+            });
+            set((state) => patch(state, id, { title: extractedTitle }));
+          }
+          // persist 在 set 返回原 state 时也会写，必须在调用 set 之前跳过。
+          return;
+        }
+
         set((state) => {
           const conversation = state.conversations[id];
           if (!conversation) return state;
-
-          // 桌面建的会话在 spawn 时就有标题；空标题只会出现在手机建的会话上。
-          // 当首条用户消息到达时（message-upsert），无论该会话是否是桌面 hot 缓存，
-          // 都必须捕获首条消息来生成截断标题，并在开启设置时触发标题总结。
-          const isUserMessageUpsert =
-            event.type === 'message-upsert' && event.message.role === 'user';
-          let extractedTitle: string | undefined;
-          let rawUserText: string | undefined;
-          if (!conversation.title && isUserMessageUpsert) {
-            rawUserText = userMessageRawText(event.message);
-            if (rawUserText) {
-              extractedTitle = truncateTitle(rawUserText);
-            }
-          }
-
-          if (
-            isBulkyAgentEvent(event.type) &&
-            !isMessageCacheHot(id, viewedFromState(state), lastViewedAt, Date.now())
-          ) {
-            if (extractedTitle && rawUserText) {
-              trySummarizeTitle(id, rawUserText, extractedTitle, {
-                providerId: conversation.lastProviderId,
-                modelId: conversation.lastModelId,
-              });
-              return patch(state, id, { title: extractedTitle });
-            }
-            return state;
-          }
           // 冷缓存清空后用户先发了一句（乐观回显占位），worker 推来的 upsert 带原 index 对不上
           // 本地权威区：reducer 会丢正文只推 seq，若不补要 snapshot，历史与正在跑的工具卡永远不出现。
           if (
@@ -2434,7 +2432,7 @@ export const useSessionsStore = create<SessionsState>()(
       version: SESSIONS_VERSION,
       migrate: (persisted, version) => migrateSessions(persisted, version) as SessionsState,
       // 存 settings.json（localStorage 按 origin 隔离，dev 与打包版会分家）
-      storage: createJSONStorage(() => electronStorage),
+      storage: createElectronPersistStorage(),
       // 只存元数据：messages 由 worker snapshot 补回（刷新场景）；app 重启后拿不回则标结束
       partialize: (state) => ({
         conversations: Object.fromEntries(
@@ -2448,6 +2446,8 @@ export const useSessionsStore = create<SessionsState>()(
                 conversation.lastActiveAt ??
                 conversation.createdAt,
               messages: [],
+              // 命令列表按会话重复且可能很大，由 worker snapshot / commands 事件恢复。
+              commands: [],
               customEntries: [],
               dispatchMainEvents: {},
               generation: undefined,

--- a/src/renderer/stores/settings/coalescedStorage.test.ts
+++ b/src/renderer/stores/settings/coalescedStorage.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as storageModule from './storage';
+
+const writeKey = vi.fn<(name: string, value: unknown) => Promise<boolean>>();
+const read = vi.fn<() => Promise<unknown>>();
+vi.stubGlobal('window', { electronAPI: { settings: { read, writeKey } } });
+
+const storage = storageModule.createElectronPersistStorage<{ revision: number }>();
+const value = (revision: number) => ({ state: { revision }, version: 1 });
+const deferred = () => {
+  let resolve!: (value: boolean) => void;
+  const promise = new Promise<boolean>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+describe('对象级会话持久化', () => {
+  beforeEach(() => {
+    writeKey.mockReset();
+    read.mockReset();
+  });
+
+  it('流式突发只发送首值和最新值，同键最多一个在途写入', async () => {
+    storageModule.openPersistWriteGate('burst');
+    const first = deferred();
+    writeKey.mockReturnValueOnce(first.promise).mockResolvedValue(true);
+    const drained = storage.setItem('burst', value(0));
+    for (let revision = 1; revision <= 600; revision++) {
+      storage.setItem('burst', value(revision));
+    }
+    expect(writeKey).toHaveBeenCalledTimes(1);
+    first.resolve(true);
+    await drained;
+    expect(writeKey).toHaveBeenCalledTimes(2);
+    expect(writeKey).toHaveBeenLastCalledWith('burst', value(600));
+  });
+
+  it('主进程拒绝写入可观察，并继续保存最新值及后续批次', async () => {
+    storageModule.openPersistWriteGate('failure');
+    const first = deferred();
+    writeKey.mockReturnValueOnce(first.promise).mockResolvedValue(true);
+    const drained = storage.setItem('failure', value(1));
+    storage.setItem('failure', value(2));
+    first.resolve(false);
+    await expect(drained).rejects.toThrow('failure');
+    expect(writeKey).toHaveBeenLastCalledWith('failure', value(2));
+    await storage.setItem('failure', value(3));
+    expect(writeKey).toHaveBeenLastCalledWith('failure', value(3));
+  });
+
+  it('读取等待该键最新状态写完，不能水合回在途更新之前的旧值', async () => {
+    storageModule.openPersistWriteGate('read-after-write');
+    const first = deferred();
+    writeKey.mockReturnValueOnce(first.promise).mockResolvedValue(true);
+    read.mockResolvedValue({ 'read-after-write': value(2) });
+    storage.setItem('read-after-write', value(1));
+    storage.setItem('read-after-write', value(2));
+    const reading = storage.getItem('read-after-write');
+    expect(read).not.toHaveBeenCalled();
+    first.resolve(true);
+    await expect(reading).resolves.toEqual(value(2));
+  });
+
+  it('同批次共享完成结果，删除覆盖待写更新，删除之后可以重新写入', async () => {
+    storageModule.openPersistWriteGate('delete');
+    const first = deferred();
+    writeKey.mockReturnValueOnce(first.promise).mockResolvedValue(true);
+    const drained = storage.setItem('delete', value(1));
+    expect(storage.setItem('delete', value(2))).toBe(drained);
+    expect(storage.removeItem('delete')).toBe(drained);
+    first.resolve(true);
+    await drained;
+    expect(writeKey).toHaveBeenCalledTimes(2);
+    expect(writeKey).toHaveBeenLastCalledWith('delete', undefined);
+    await storage.setItem('delete', value(3));
+    expect(writeKey).toHaveBeenLastCalledWith('delete', value(3));
+  });
+
+  it('待写删除之后的新状态覆盖删除，各个键独立推进', async () => {
+    storageModule.openPersistWriteGate('replace-delete');
+    storageModule.openPersistWriteGate('independent');
+    const first = deferred();
+    writeKey.mockReturnValueOnce(first.promise).mockResolvedValue(true);
+    const drained = storage.setItem('replace-delete', value(1));
+    storage.removeItem('replace-delete');
+    storage.setItem('replace-delete', value(3));
+    await storage.setItem('independent', value(9));
+    expect(writeKey).toHaveBeenLastCalledWith('independent', value(9));
+    first.resolve(true);
+    await drained;
+    expect(writeKey.mock.calls).toEqual([
+      ['replace-delete', value(1)],
+      ['independent', value(9)],
+      ['replace-delete', value(3)],
+    ]);
+  });
+
+  it('读回不提前开闸，水合前写入丢弃且不会在开闸后补写', async () => {
+    read.mockResolvedValue({ gated: value(7) });
+    expect(await storage.getItem('gated')).toEqual(value(7));
+    const generation = storageModule.getWriteGeneration();
+    await storage.setItem('gated', value(0));
+    await storage.removeItem('gated');
+    expect(storageModule.getWriteGeneration()).toBe(generation);
+    storageModule.openPersistWriteGate('gated');
+    expect(writeKey).not.toHaveBeenCalled();
+    writeKey.mockResolvedValue(true);
+    await storage.setItem('gated', value(8));
+    expect(writeKey).toHaveBeenCalledExactlyOnceWith('gated', value(8));
+  });
+
+  it('合并中的每次本地更新都计入同步代数，其他键的闸门仍关闭', async () => {
+    storageModule.openPersistWriteGate('generation');
+    const first = deferred();
+    writeKey.mockReturnValueOnce(first.promise).mockResolvedValue(true);
+    const generation = storageModule.getWriteGeneration();
+    const drained = storage.setItem('generation', value(1));
+    storage.setItem('generation', value(2));
+    storage.removeItem('generation');
+    storage.setItem('still-closed', value(5));
+    expect(storageModule.getWriteGeneration()).toBe(generation + 3);
+    first.resolve(true);
+    await drained;
+  });
+
+  it('IPC 拒绝与同步抛错均不会锁住队列，后续写入仍然成功', async () => {
+    storageModule.openPersistWriteGate('ipc-error');
+    writeKey.mockRejectedValueOnce(new Error('ipc down')).mockResolvedValue(true);
+    await expect(storage.setItem('ipc-error', value(1))).rejects.toThrow('ipc down');
+    writeKey.mockImplementationOnce(() => {
+      throw new Error('bridge down');
+    });
+    await expect(storage.setItem('ipc-error', value(2))).rejects.toThrow('bridge down');
+    await storage.setItem('ipc-error', value(3));
+    expect(writeKey).toHaveBeenLastCalledWith('ipc-error', value(3));
+  });
+});

--- a/src/renderer/stores/settings/storage.ts
+++ b/src/renderer/stores/settings/storage.ts
@@ -1,6 +1,7 @@
 /**
  * Zustand persist 存储适配器：通过 IPC 持久化到主进程的 settings.json
  */
+import type { PersistStorage, StorageValue } from 'zustand/middleware';
 
 /**
  * 已完成首次水合（persist 已 merge 磁盘状态）的 store 名。
@@ -13,7 +14,7 @@
  */
 const hydratedNames = new Set<string>();
 
-/** 本渲染进程发出的落盘次数。跨窗口同步用它判断重读在途时是否有本地写抢跑。 */
+/** 本渲染进程接受的落盘更新次数（含合并中的更新），用于检测跨窗口重读期间的本地变更。 */
 let writeGeneration = 0;
 export const getWriteGeneration = (): number => writeGeneration;
 
@@ -44,3 +45,67 @@ export const electronStorage = {
     await window.electronAPI.settings.writeKey(name, undefined);
   },
 };
+
+/**
+ * 流式会话使用对象级入口，在序列化和跨进程复制之前合并更新。
+ * 同键只保留一个在途写入与一个最新待写值；整个批次共享完成 Promise。
+ */
+export function createElectronPersistStorage<State>(): PersistStorage<State> {
+  type Write = { value: StorageValue<State> | undefined };
+  type Queue = { pending?: Write; done: Promise<void> };
+  const queues = new Map<string, Queue>();
+
+  function enqueue(name: string, value: StorageValue<State> | undefined): Promise<void> | void {
+    if (!hydratedNames.has(name)) return;
+    writeGeneration++;
+    const existing = queues.get(name);
+    if (existing) {
+      existing.pending = { value };
+      return existing.done;
+    }
+
+    let finish!: () => void;
+    let fail!: (error: unknown) => void;
+    const queue: Queue = {
+      pending: { value },
+      done: new Promise<void>((resolve, reject) => {
+        finish = resolve;
+        fail = reject;
+      }),
+    };
+    queues.set(name, queue);
+    // persist 通常不等待写入；报告失败并标记已处理，同时保留调用方可等待的拒绝结果。
+    void queue.done.catch((error: unknown) => console.error('会话持久化失败', name, error));
+    async function drain(): Promise<void> {
+      let failure: { error: unknown } | undefined;
+      while (queue.pending) {
+        const next = queue.pending;
+        queue.pending = undefined;
+        try {
+          if (!(await window.electronAPI.settings.writeKey(name, next.value))) {
+            throw new Error(`写入 ${name} 失败`);
+          }
+        } catch (error) {
+          failure ??= { error };
+        }
+      }
+      queues.delete(name);
+      if (failure) fail(failure.error);
+      else finish();
+    }
+    void drain();
+    return queue.done;
+  }
+
+  return {
+    async getItem(name) {
+      await queues.get(name)?.done;
+      const data = await window.electronAPI.settings.read();
+      return data && typeof data === 'object' && name in data
+        ? (data as Record<string, StorageValue<State>>)[name]
+        : null;
+    },
+    setItem: enqueue,
+    removeItem: (name) => enqueue(name, undefined),
+  };
+}


### PR DESCRIPTION
## 问题

修复会话流式更新期间的一条 renderer OOM 路径：渲染进程退出后，现有 `render-process-gone` 恢复逻辑会重载窗口，表现为白屏后整体刷新。

原会话 store 的每次更新都会经过 `createJSONStorage`，对整份会话元数据进行 JSON 编解码并发送 IPC。大量重复的 `commands` 放大每笔数据；主进程磁盘防抖发生在 IPC 收包之后，无法约束 renderer 的在途副本。Zustand persist 即使收到 `set(state => state)` 也会触发持久化。

## 修改

- 会话接入对象级 `createElectronPersistStorage`，在 JSON 编解码和 contextBridge 复制之前合并更新：每键最多一个在途写入和一个最新待写值，首笔立即发送，批次共享完成 Promise。
- 保留同键更新/删除顺序、水合闸门和写入代数；读取等待当前批次完成；写入失败可观察且不会锁死队列。
- 会话持久化投影清空 `commands`，内存中的命令仍由 worker snapshot / commands 事件恢复，不改变现有数据版本或 IPC 协议。
- 冷后台大型事件在调用 `set` 前跳过，保留无标题会话从首条用户消息提取和总结标题的行为。
- 补充 12 个回归用例及两份持久化规范。设置 store 原适配器不变；未增加依赖。
- 不修改 Electron / V8 运行时 flag、堆上限、GPU、沙箱或打包配置；实验专用参数未进入产品代码。

## 验证

- TDD：先确认旧实现的突发写入、命令投影及冷事件用例失败，再实现修复；补测失败恢复、读写顺序、删除、独立键及水合闸门。
- `pnpm exec vitest run src/renderer/stores/sessions src/renderer/stores/settings`：21 个文件、312 个测试通过。
- 修改的 4 个 TypeScript 文件 `biome check` 通过；`git diff --check` 通过。
- `pnpm build` 通过。
- 本地 Apple Silicon DMG 打包及完整性校验通过；包内原生模块加载、内存 SQLite 和 PTY 子进程退出验证通过，打包代码的隔离界面启动通过。本地使用 ad-hoc 签名，未发布 release。
- 隔离 Electron 43.4.1 / macOS ARM64 实验直接加载本次真实适配器，使用 177 个合成会话，元数据序列化长度 2,843,548 字符，特意保留大命令列表以单独验证队列。默认堆和 256 MB old-space 限制下，三批各 600 次 IPC 驱动更新都正常退出：共 1,800 次更新仅产生 6 次写入，各批最终值均正确，renderer 峰值工作集约 134 MiB。该实验未修改已安装应用或真实会话。

### 既有检查失败（未扩大本 PR 修复范围）

在独立 worktree 对相同依赖下的上游基线 `64714a8` 运行检查，并与修复分支对比：

- 全量 Vitest：基线 2,002 通过 / 16 失败 / 4 跳过；修复后 2,014 通过 / 16 失败 / 4 跳过。失败用例名称完全一致，分布在 `supervisor.agentDispatch.test.ts`、`supervisor.coworkerWait.test.ts` 和 `productCapabilityCoverage.test.ts`，没有新增失败。
- `pnpm typecheck`：仍有基线类型错误，集中在 `learn.test.ts`、`memory/pipeline.test.ts`、`messageCoworker.test.ts`、`sessions/stallTimeout.test.ts` 和 `productCapabilityCoverage.fixture.ts`；本次修改文件无错误。
- 仓库全局 Biome 有既有错误，本 PR 修改文件检查通过。

本 PR 修复已复现的会话持久化 OOM 路径，不声称所有白屏都只有这一种来源。诊断原始数据、真实会话、临时实验脚本均未包含在提交中。
