### PR TITLE
fix(pair): VPN 掉线后钉缓存 IP 并拆半开中继链

### DIFF
--- a/packages/pair/src/index.ts
+++ b/packages/pair/src/index.ts
@@ -58,3 +58,21 @@ export {
   type PairedDevice,
   toWebSocketUrl,
 } from './relay';
+export {
+  createCachedHostLookup,
+  isMagicDnsOnly,
+  type NetworkInterfaceSnapshot,
+  type NudgeReason,
+  networkFingerprint,
+  parseLiteralHost,
+  parseRelayHostCache,
+  parseResolvConfNameservers,
+  parseScutilGlobalNameservers,
+  pickRelayConnectAddress,
+  type RelayHostAddress,
+  serializeRelayHostCache,
+  shouldReplaceOnNudge,
+  shouldSkipRelayLookup,
+  shouldUsePinnedRelaySocket,
+  TAILSCALE_MAGIC_DNS,
+} from './revive';

--- a/packages/pair/src/revive.test.ts
+++ b/packages/pair/src/revive.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createCachedHostLookup,
+  isMagicDnsOnly,
+  networkFingerprint,
+  parseLiteralHost,
+  parseRelayHostCache,
+  parseResolvConfNameservers,
+  parseScutilGlobalNameservers,
+  pickRelayConnectAddress,
+  serializeRelayHostCache,
+  shouldReplaceOnNudge,
+  shouldSkipRelayLookup,
+  shouldUsePinnedRelaySocket,
+} from './revive';
+
+describe('networkFingerprint', () => {
+  it('忽略回环 / 链路本地，按网卡+地址排序', () => {
+    const left = networkFingerprint({
+      lo0: [{ address: '127.0.0.1', family: 'IPv4', internal: true }],
+      en0: [{ address: '192.168.1.8', family: 'IPv4', internal: false }],
+      utun4: [{ address: 'fe80::1', family: 'IPv6', internal: false }],
+    });
+    const right = networkFingerprint({
+      utun4: [{ address: 'fe80::1', family: 6, internal: false }],
+      en0: [{ address: '192.168.1.8', family: 4, internal: false }],
+      lo0: [{ address: '127.0.0.1', family: 4, internal: true }],
+    });
+    expect(left).toBe(right);
+    expect(left).toContain('en0|IPv4|192.168.1.8');
+    expect(left).not.toContain('127.0.0.1');
+    expect(left).not.toContain('fe80:');
+  });
+
+  it('VPN 隧道地址消失时指纹变化', () => {
+    const withVpn = networkFingerprint({
+      en0: [{ address: '192.168.1.8', family: 'IPv4', internal: false }],
+      utun4: [{ address: '100.64.0.2', family: 'IPv4', internal: false }],
+    });
+    const withoutVpn = networkFingerprint({
+      en0: [{ address: '192.168.1.8', family: 'IPv4', internal: false }],
+    });
+    expect(withVpn).not.toBe(withoutVpn);
+  });
+});
+
+describe('shouldReplaceOnNudge', () => {
+  it('无 socket 一律重连', () => {
+    expect(shouldReplaceOnNudge('resume', false)).toBe(true);
+    expect(shouldReplaceOnNudge('visibility', false)).toBe(true);
+  });
+
+  it('活链：网络变化 / 重新上线拆 socket，睡眠与回前台只探活', () => {
+    expect(shouldReplaceOnNudge('network-change', true)).toBe(true);
+    expect(shouldReplaceOnNudge('online', true)).toBe(true);
+    expect(shouldReplaceOnNudge('resume', true)).toBe(false);
+    expect(shouldReplaceOnNudge('visibility', true)).toBe(false);
+  });
+});
+
+describe('relay lookup 决策', () => {
+  it('系统 DNS 全是 MagicDNS 时视为死解析器', () => {
+    expect(isMagicDnsOnly(['100.100.100.100'])).toBe(true);
+    expect(isMagicDnsOnly(['100.100.100.100', '100.100.100.100'])).toBe(true);
+    expect(isMagicDnsOnly(['100.100.100.100', '1.1.1.1'])).toBe(false);
+    expect(isMagicDnsOnly([])).toBe(false);
+  });
+
+  it('有缓存且 MagicDNS 独占时跳过 lookup', () => {
+    expect(shouldSkipRelayLookup(true, true)).toBe(true);
+    expect(shouldSkipRelayLookup(false, true)).toBe(false);
+    expect(shouldSkipRelayLookup(true, false)).toBe(false);
+  });
+
+  it('字面量 IP 不再走 DNS', () => {
+    expect(parseLiteralHost('1.2.3.4')).toEqual({ address: '1.2.3.4', family: 4 });
+    expect(parseLiteralHost('[2001:db8::1]')).toEqual({ address: '2001:db8::1', family: 6 });
+    expect(parseLiteralHost('enso-relay.j3.do')).toBeNull();
+  });
+
+  it('scutil 只取全局 nameserver，忽略 scoped 残留', () => {
+    const output = [
+      'DNS configuration',
+      '',
+      'resolver #1',
+      '  nameserver[0] : 100.100.100.100',
+      '',
+      'DNS configuration (for scoped queries)',
+      '',
+      'resolver #2',
+      '  nameserver[0] : 1.1.1.1',
+    ].join('\n');
+    expect(parseScutilGlobalNameservers(output)).toEqual(['100.100.100.100']);
+  });
+
+  it('resolv.conf 去重 nameserver', () => {
+    expect(
+      parseResolvConfNameservers('# comment\nnameserver 1.1.1.1\nnameserver 1.1.1.1\n')
+    ).toEqual(['1.1.1.1']);
+  });
+
+  it('选址：字面量优先，跳过 lookup 时用缓存，否则 lookup 再回落缓存', () => {
+    expect(
+      pickRelayConnectAddress({
+        hostname: '9.9.9.9',
+        cache: { address: '1.1.1.1', family: 4 },
+        lookup: { address: '8.8.8.8', family: 4 },
+        skipLookup: true,
+      })
+    ).toEqual({ address: '9.9.9.9', family: 4 });
+    expect(
+      pickRelayConnectAddress({
+        hostname: 'enso-relay.j3.do',
+        cache: { address: '1.1.1.1', family: 4 },
+        lookup: { address: '8.8.8.8', family: 4 },
+        skipLookup: true,
+      })
+    ).toEqual({ address: '1.1.1.1', family: 4 });
+    expect(
+      pickRelayConnectAddress({
+        hostname: 'enso-relay.j3.do',
+        cache: { address: '1.1.1.1', family: 4 },
+        lookup: { address: '8.8.8.8', family: 4 },
+        skipLookup: false,
+      })
+    ).toEqual({ address: '8.8.8.8', family: 4 });
+    expect(
+      pickRelayConnectAddress({
+        hostname: 'enso-relay.j3.do',
+        cache: { address: '1.1.1.1', family: 4 },
+        lookup: null,
+        skipLookup: false,
+      })
+    ).toEqual({ address: '1.1.1.1', family: 4 });
+  });
+});
+
+describe('shouldUsePinnedRelaySocket', () => {
+  it('只有 DNS 不可用且已有解析结果时才钉 IP，避免绕过 Chromium 代理', () => {
+    const resolved = { address: '1.2.3.4', family: 4 as const };
+    expect(
+      shouldUsePinnedRelaySocket({
+        hostname: 'enso-relay.j3.do',
+        resolved,
+        skipLookup: true,
+        lookupFailed: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldUsePinnedRelaySocket({
+        hostname: 'enso-relay.j3.do',
+        resolved,
+        skipLookup: false,
+        lookupFailed: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldUsePinnedRelaySocket({
+        hostname: 'enso-relay.j3.do',
+        resolved,
+        skipLookup: false,
+        lookupFailed: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldUsePinnedRelaySocket({
+        hostname: 'enso-relay.j3.do',
+        resolved: null,
+        skipLookup: true,
+        lookupFailed: true,
+      })
+    ).toBe(false);
+    expect(
+      shouldUsePinnedRelaySocket({
+        hostname: '1.2.3.4',
+        resolved,
+        skipLookup: true,
+        lookupFailed: true,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('createCachedHostLookup', () => {
+  it('字面量不查 DNS', async () => {
+    const lookup = createCachedHostLookup({
+      cache: new Map(),
+      readNameservers: () => ['1.1.1.1'],
+      lookup: () => {
+        throw new Error('should not lookup');
+      },
+    });
+    await expect(lookup('8.8.8.8')).resolves.toEqual({ address: '8.8.8.8', family: 4 });
+  });
+
+  it('MagicDNS 独占且有缓存时不查 DNS', async () => {
+    const cache = new Map([['enso-relay.j3.do', { address: '9.9.9.9', family: 4 as const }]]);
+    const lookup = createCachedHostLookup({
+      cache,
+      readNameservers: () => ['100.100.100.100'],
+      lookup: () => {
+        throw new Error('should not lookup');
+      },
+    });
+    await expect(lookup('enso-relay.j3.do')).resolves.toEqual({
+      address: '9.9.9.9',
+      family: 4,
+    });
+  });
+
+  it('lookup 成功写入缓存；失败回落缓存', async () => {
+    const cache = new Map<string, { address: string; family: 4 | 6 }>();
+    const lookup = createCachedHostLookup({
+      cache,
+      readNameservers: () => ['1.1.1.1'],
+      lookup: async (hostname) => {
+        if (hostname === 'ok.example') return { address: '1.2.3.4', family: 4 };
+        throw new Error('ENOTFOUND');
+      },
+    });
+    await expect(lookup('ok.example')).resolves.toEqual({ address: '1.2.3.4', family: 4 });
+    expect(cache.get('ok.example')).toEqual({ address: '1.2.3.4', family: 4 });
+
+    cache.set('dead.example', { address: '5.5.5.5', family: 4 });
+    await expect(lookup('dead.example')).resolves.toEqual({ address: '5.5.5.5', family: 4 });
+  });
+});
+
+describe('relay host cache 落盘形状', () => {
+  it('丢掉脏条目，往返合法记录', () => {
+    const parsed = parseRelayHostCache({
+      'enso-relay.j3.do': { address: '1.2.3.4', family: 4 },
+      bad: { address: 'nope', family: 4 },
+      empty: null,
+    });
+    expect(parsed.get('enso-relay.j3.do')).toEqual({ address: '1.2.3.4', family: 4 });
+    expect(parsed.has('bad')).toBe(false);
+    expect(JSON.parse(serializeRelayHostCache(parsed))).toEqual({
+      'enso-relay.j3.do': { address: '1.2.3.4', family: 4 },
+    });
+  });
+});

--- a/packages/pair/src/revive.ts
+++ b/packages/pair/src/revive.ts
@@ -1,0 +1,148 @@
+/** VPN 掉线后的即时唤醒：网卡指纹、拆半开 socket、避开死掉的 MagicDNS。 */
+
+export const TAILSCALE_MAGIC_DNS = '100.100.100.100';
+
+export type NudgeReason = 'resume' | 'online' | 'network-change' | 'visibility';
+
+export type RelayHostAddress = { address: string; family: 4 | 6 };
+
+export type NetworkInterfaceAddress = {
+  address: string;
+  family: string | number;
+  internal: boolean;
+};
+
+export type NetworkInterfaceSnapshot = Record<string, NetworkInterfaceAddress[] | undefined>;
+
+function familyLabel(family: string | number): 'IPv4' | 'IPv6' {
+  return family === 6 || family === 'IPv6' ? 'IPv6' : 'IPv4';
+}
+
+function isLinkLocalIPv6(address: string, family: 'IPv4' | 'IPv6'): boolean {
+  return family === 'IPv6' && address.toLowerCase().startsWith('fe80:');
+}
+
+/** 非回环、非链路本地地址的稳定指纹。VPN utun 增减会变。 */
+export function networkFingerprint(nics: NetworkInterfaceSnapshot): string {
+  const rows: string[] = [];
+  for (const [name, addrs] of Object.entries(nics)) {
+    if (!addrs) continue;
+    for (const addr of addrs) {
+      if (addr.internal) continue;
+      const family = familyLabel(addr.family);
+      if (isLinkLocalIPv6(addr.address, family)) continue;
+      rows.push(`${name}|${family}|${addr.address}`);
+    }
+  }
+  rows.sort();
+  return rows.join(';');
+}
+
+/** 链路已死但 close 不来时：网络切换 / 重新上线拆旧 socket，睡眠与回前台只 ping。 */
+export function shouldReplaceOnNudge(reason: NudgeReason, hasSocket: boolean): boolean {
+  if (!hasSocket) return true;
+  return reason === 'network-change' || reason === 'online';
+}
+
+export function isMagicDnsOnly(nameservers: readonly string[]): boolean {
+  return nameservers.length > 0 && nameservers.every((ns) => ns === TAILSCALE_MAGIC_DNS);
+}
+
+export function shouldSkipRelayLookup(hasCache: boolean, magicDnsOnly: boolean): boolean {
+  return hasCache && magicDnsOnly;
+}
+
+export function parseLiteralHost(hostname: string): RelayHostAddress | null {
+  const host =
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)) return { address: host, family: 4 };
+  if (host.includes(':') && !host.includes('.')) return { address: host, family: 6 };
+  return null;
+}
+
+/** 只读 scutil 的全局段，scoped 查询常残留已死隧道的 DNS。 */
+export function parseScutilGlobalNameservers(output: string): string[] {
+  const scoped = output.indexOf('\nDNS configuration (for scoped queries)');
+  const global = scoped === -1 ? output : output.slice(0, scoped);
+  return [
+    ...new Set(Array.from(global.matchAll(/nameserver\[\d+\]\s*:\s*(\S+)/g), (match) => match[1])),
+  ];
+}
+
+export function parseResolvConfNameservers(text: string): string[] {
+  const servers: string[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const match = /^\s*nameserver\s+(\S+)/.exec(line);
+    if (match) servers.push(match[1]);
+  }
+  return [...new Set(servers)];
+}
+
+/** Chromium WebSocket 默认走系统代理；只有 DNS 挂了才钉 IP，避免平时绕过代理。 */
+export function shouldUsePinnedRelaySocket(input: {
+  hostname: string;
+  resolved: RelayHostAddress | null;
+  skipLookup: boolean;
+  lookupFailed: boolean;
+}): boolean {
+  if (!input.resolved || parseLiteralHost(input.hostname)) return false;
+  return input.skipLookup || input.lookupFailed;
+}
+
+export function pickRelayConnectAddress(input: {
+  hostname: string;
+  cache: RelayHostAddress | null;
+  lookup: RelayHostAddress | null;
+  skipLookup: boolean;
+}): RelayHostAddress | null {
+  const literal = parseLiteralHost(input.hostname);
+  if (literal) return literal;
+  if (input.skipLookup) return input.cache;
+  return input.lookup ?? input.cache;
+}
+
+function isRelayHostAddress(value: unknown): value is RelayHostAddress {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as { address?: unknown; family?: unknown };
+  if (record.family !== 4 && record.family !== 6) return false;
+  if (typeof record.address !== 'string') return false;
+  return parseLiteralHost(record.family === 6 ? `[${record.address}]` : record.address) !== null;
+}
+
+export function parseRelayHostCache(raw: unknown): Map<string, RelayHostAddress> {
+  const cache = new Map<string, RelayHostAddress>();
+  if (typeof raw !== 'object' || raw === null) return cache;
+  for (const [hostname, value] of Object.entries(raw)) {
+    if (!hostname || parseLiteralHost(hostname)) continue;
+    if (isRelayHostAddress(value)) cache.set(hostname, value);
+  }
+  return cache;
+}
+
+export function serializeRelayHostCache(cache: Map<string, RelayHostAddress>): string {
+  return JSON.stringify(Object.fromEntries(cache));
+}
+
+export function createCachedHostLookup(deps: {
+  cache: Map<string, RelayHostAddress>;
+  readNameservers: () => readonly string[];
+  lookup: (hostname: string) => Promise<RelayHostAddress> | RelayHostAddress;
+}): (hostname: string) => Promise<RelayHostAddress | null> {
+  return async (hostname) => {
+    const cache = deps.cache.get(hostname) ?? null;
+    const skipLookup = shouldSkipRelayLookup(
+      cache !== null,
+      isMagicDnsOnly(deps.readNameservers())
+    );
+    let resolved: RelayHostAddress | null = null;
+    if (!skipLookup && !parseLiteralHost(hostname)) {
+      try {
+        resolved = await deps.lookup(hostname);
+        if (resolved) deps.cache.set(hostname, resolved);
+      } catch {
+        resolved = null;
+      }
+    }
+    return pickRelayConnectAddress({ hostname, cache, lookup: resolved, skipLookup });
+  };
+}

--- a/packages/phone/src/App.tsx
+++ b/packages/phone/src/App.tsx
@@ -177,19 +177,25 @@ export function App() {
     // 切后台时系统会掐死或冻结 socket 且不触发 close：回前台/网络恢复立即探活。
     // 退后台瞬间赶在冻结前上报不可见：桌面据此把关键事件转系统推送
     //（半开 socket 不会 close，光靠 peer-left 桌面要很久才知道手机不在看）
-    const nudge = () => {
+    const onVisibility = () => {
       if (document.visibilityState === 'visible') {
-        client.nudge();
+        client.nudge('visibility');
         client.send({ type: 'presence', visible: true });
       } else {
         client.send({ type: 'presence', visible: false });
       }
     };
-    document.addEventListener('visibilitychange', nudge);
-    window.addEventListener('online', nudge);
+    const onOnline = () => {
+      if (document.visibilityState === 'visible') {
+        client.nudge('online');
+        client.send({ type: 'presence', visible: true });
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('online', onOnline);
     return () => {
-      document.removeEventListener('visibilitychange', nudge);
-      window.removeEventListener('online', nudge);
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('online', onOnline);
       client.close();
       clientRef.current = null;
     };

--- a/packages/phone/src/client.ts
+++ b/packages/phone/src/client.ts
@@ -5,6 +5,7 @@ import {
   fromBase64Url,
   type Heartbeat,
   type HostToPhone,
+  type NudgeReason,
   openFrame,
   type PairedDevice,
   type PhoneToHost,
@@ -12,6 +13,7 @@ import {
   type ProjectGroupEntry,
   type ProviderEntry,
   sealFrame,
+  shouldReplaceOnNudge,
   toWebSocketUrl,
 } from '@enso/pair';
 import {
@@ -156,17 +158,23 @@ export class PairClient {
     };
   }
 
-  /** 回前台/网络恢复时调用：死链立即重连（跳过退避），活链立即探测 */
-  nudge(): void {
+  /** 回前台只探活；网络恢复拆半开链，死链立即重连 */
+  nudge(reason: NudgeReason = 'visibility'): void {
     if (this.closed || this.revoked) return;
-    if (this.ws) {
-      this.heartbeat?.probe();
+    if (shouldReplaceOnNudge(reason, this.ws !== null)) {
+      if (this.timer) clearTimeout(this.timer);
+      this.timer = null;
+      this.attempt = 0;
+      if (this.ws) {
+        try {
+          this.ws.close();
+        } catch {}
+      } else {
+        this.connect();
+      }
       return;
     }
-    if (this.timer) clearTimeout(this.timer);
-    this.timer = null;
-    this.attempt = 0;
-    this.connect();
+    this.heartbeat?.probe();
   }
 
   close(): void {

--- a/src/main/services/pairGuest.ts
+++ b/src/main/services/pairGuest.ts
@@ -12,6 +12,7 @@ import {
   parsePairUri,
   revokePairing,
   sealFrame,
+  shouldReplaceOnNudge,
   toBase64Url,
   toWebSocketUrl,
 } from '@enso/pair';
@@ -32,6 +33,10 @@ import {
   saveNodes,
   upsertNode,
 } from './nodeStore';
+import { startPairNetworkWatch } from './pairNetworkWatch';
+import { seedRelayHostCache } from './pairRelayLookup';
+import { openPairRelayWebSocket } from './pairRelayOpen';
+import { loadRelayHostCache } from './pairStore';
 
 /**
  * 「连接到节点」guest 端：本机连到别的 EnsoCode 桌面（对方是 pairHost）。
@@ -50,6 +55,7 @@ interface Connection {
   attempt: number;
   timer: NodeJS.Timeout | null;
   closed: boolean;
+  generation: number;
 }
 
 const connections = new Map<string, Connection>();
@@ -98,30 +104,48 @@ function notifyStatus(): void {
 // ── 生命周期 ──────────────────────────────────────────────────────────
 
 let resumeHooked = false;
+let stopNetworkWatch: (() => void) | null = null;
+let cacheSeeded = false;
+
+function ensureRelayCacheSeeded(): void {
+  if (cacheSeeded) return;
+  cacheSeeded = true;
+  seedRelayHostCache(loadRelayHostCache());
+}
 
 export function startPairGuest(): void {
+  ensureRelayCacheSeeded();
   if (!resumeHooked) {
     resumeHooked = true;
     // 睡眠唤醒后 TCP 多半已死但 close 事件不会来：活链立即探测，死链立即重连
-    powerMonitor.on('resume', probeAll);
+    powerMonitor.on('resume', () => reviveAll('resume'));
+    stopNetworkWatch = startPairNetworkWatch({ onChange: () => reviveAll('network-change') });
   }
   for (const node of loadNodes()) openConnection(node);
 }
 
-function probeAll(): void {
+function reviveAll(reason: 'resume' | 'network-change'): void {
   for (const conn of connections.values()) {
     if (conn.closed) continue;
-    if (conn.ws) {
-      conn.heartbeat?.probe();
-    } else {
+    if (shouldReplaceOnNudge(reason, conn.ws !== null)) {
       if (conn.timer) clearTimeout(conn.timer);
       conn.attempt = 0;
-      connect(conn);
+      if (conn.ws) {
+        try {
+          conn.ws.close();
+        } catch {}
+      } else {
+        connect(conn);
+      }
+      continue;
     }
+    conn.heartbeat?.probe();
   }
 }
 
 export function stopPairGuest(): void {
+  stopNetworkWatch?.();
+  stopNetworkWatch = null;
   for (const conn of connections.values()) closeConnection(conn);
   connections.clear();
 }
@@ -232,6 +256,7 @@ function openConnection(node: RemoteNode): void {
     attempt: 0,
     timer: null,
     closed: false,
+    generation: 0,
   };
   connections.set(node.nodeId, conn);
   connect(conn);
@@ -239,13 +264,21 @@ function openConnection(node: RemoteNode): void {
 
 function connect(conn: Connection): void {
   if (conn.closed) return;
+  const generation = ++conn.generation;
   const base = toWebSocketUrl(conn.node.relayUrl);
   const url = `${base}/v1/pair/${encodeURIComponent(conn.node.pairId)}?role=guest&token=${encodeURIComponent(conn.node.token)}`;
-  let ws: WebSocket;
-  try {
-    ws = new WebSocket(url);
-  } catch {
-    scheduleReconnect(conn);
+  void openPairRelayWebSocket(url)
+    .then((ws) => attachGuestSocket(conn, ws, generation))
+    .catch(() => {
+      if (!conn.closed && conn.generation === generation) scheduleReconnect(conn);
+    });
+}
+
+function attachGuestSocket(conn: Connection, ws: WebSocket, generation: number): void {
+  if (conn.closed || conn.generation !== generation) {
+    try {
+      ws.close();
+    } catch {}
     return;
   }
   ws.binaryType = 'arraybuffer';

--- a/src/main/services/pairHost.ts
+++ b/src/main/services/pairHost.ts
@@ -18,6 +18,7 @@ import {
   pollHostPairing,
   revokePairing,
   sealFrame,
+  shouldReplaceOnNudge,
   startHostPairing,
   type TerminalPalette,
   toBase64Url,
@@ -48,6 +49,7 @@ import { app, powerMonitor, powerSaveBlocker } from 'electron';
 import { requestSnapshot, setPinnedSessions } from './agentHost';
 import { MacosSystemSleepAssertion } from './macosSystemSleepAssertion';
 import { bumpPairMetaEpoch, flushChangedMeta, requestPairMeta } from './pairMetaFlush';
+import { startPairNetworkWatch } from './pairNetworkWatch';
 import {
   checkSetModel,
   checkSpawn,
@@ -58,9 +60,12 @@ import {
   sliceHistory,
 } from './pairPolicy';
 import { applyPairPowerTaskEvent, shouldHoldPairPowerKeepAlive } from './pairPowerKeepAlive';
+import { seedRelayHostCache } from './pairRelayLookup';
+import { openPairRelayWebSocket } from './pairRelayOpen';
 import {
   isSecureStorageAvailable,
   loadDevices,
+  loadRelayHostCache,
   loadRelayUrl,
   renameDevice as renameInList,
   saveDevices,
@@ -113,6 +118,7 @@ interface Connection {
   attempt: number;
   timer: NodeJS.Timeout | null;
   closed: boolean;
+  generation: number;
 }
 
 const connections = new Map<string, Connection>();
@@ -231,32 +237,50 @@ function syncPinnedSessions(): void {
 // ── 生命周期 ──────────────────────────────────────────────────────────
 
 let resumeHooked = false;
+let stopNetworkWatch: (() => void) | null = null;
+let cacheSeeded = false;
+
+function ensureRelayCacheSeeded(): void {
+  if (cacheSeeded) return;
+  cacheSeeded = true;
+  seedRelayHostCache(loadRelayHostCache());
+}
 
 export function startPairHost(): void {
+  ensureRelayCacheSeeded();
   if (!resumeHooked) {
     resumeHooked = true;
     // 睡眠唤醒后 TCP 多半已死但 close 事件不会来：活链立即探测，死链立即重连
-    powerMonitor.on('resume', probeAll);
+    powerMonitor.on('resume', () => reviveAll('resume'));
+    stopNetworkWatch = startPairNetworkWatch({ onChange: () => reviveAll('network-change') });
   }
   for (const device of loadDevices()) {
     openConnection(device);
   }
 }
 
-function probeAll(): void {
+function reviveAll(reason: 'resume' | 'network-change'): void {
   for (const conn of connections.values()) {
     if (conn.closed) continue;
-    if (conn.ws) {
-      conn.heartbeat?.probe();
-    } else {
+    if (shouldReplaceOnNudge(reason, conn.ws !== null)) {
       if (conn.timer) clearTimeout(conn.timer);
       conn.attempt = 0;
-      connect(conn);
+      if (conn.ws) {
+        try {
+          conn.ws.close();
+        } catch {}
+      } else {
+        connect(conn);
+      }
+      continue;
     }
+    conn.heartbeat?.probe();
   }
 }
 
 export function stopPairHost(): void {
+  stopNetworkWatch?.();
+  stopNetworkWatch = null;
   cancelPairing();
   for (const conn of connections.values()) {
     conn.closed = true;
@@ -425,6 +449,7 @@ function openConnection(device: PairedDevice): void {
     attempt: 0,
     timer: null,
     closed: false,
+    generation: 0,
   };
   connections.set(device.pairId, conn);
   connect(conn);
@@ -432,13 +457,21 @@ function openConnection(device: PairedDevice): void {
 
 function connect(conn: Connection): void {
   if (conn.closed) return;
+  const generation = ++conn.generation;
   const base = toWebSocketUrl(conn.device.relayUrl);
   const url = `${base}/v1/pair/${encodeURIComponent(conn.device.pairId)}?role=host&token=${encodeURIComponent(conn.device.token)}`;
-  let ws: WebSocket;
-  try {
-    ws = new WebSocket(url);
-  } catch {
-    scheduleReconnect(conn);
+  void openPairRelayWebSocket(url)
+    .then((ws) => attachHostSocket(conn, ws, generation))
+    .catch(() => {
+      if (!conn.closed && conn.generation === generation) scheduleReconnect(conn);
+    });
+}
+
+function attachHostSocket(conn: Connection, ws: WebSocket, generation: number): void {
+  if (conn.closed || conn.generation !== generation) {
+    try {
+      ws.close();
+    } catch {}
     return;
   }
   ws.binaryType = 'arraybuffer';

--- a/src/main/services/pairNetworkWatch.test.ts
+++ b/src/main/services/pairNetworkWatch.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startPairNetworkWatch } from './pairNetworkWatch';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('startPairNetworkWatch', () => {
+  it('网卡指纹变化时立刻通知，相同指纹不重复触发', () => {
+    vi.useFakeTimers();
+    const snapshots = [
+      { en0: [{ address: '192.168.1.8', family: 'IPv4' as const, internal: false }] },
+      { en0: [{ address: '192.168.1.8', family: 'IPv4' as const, internal: false }] },
+      {
+        en0: [{ address: '192.168.1.8', family: 'IPv4' as const, internal: false }],
+        utun4: [{ address: '100.64.0.2', family: 'IPv4' as const, internal: false }],
+      },
+    ];
+    let i = 0;
+    const onChange = vi.fn();
+    const stop = startPairNetworkWatch({
+      pollMs: 1_000,
+      readNics: () => snapshots[Math.min(i++, snapshots.length - 1)]!,
+      onChange,
+    });
+    expect(onChange).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1_000);
+    expect(onChange).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1_000);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    stop();
+  });
+});

--- a/src/main/services/pairNetworkWatch.ts
+++ b/src/main/services/pairNetworkWatch.ts
@@ -1,0 +1,22 @@
+import os from 'node:os';
+import { type NetworkInterfaceSnapshot, networkFingerprint } from '@enso/pair';
+
+const DEFAULT_POLL_MS = 3_000;
+
+export function startPairNetworkWatch(opts?: {
+  pollMs?: number;
+  readNics?: () => NetworkInterfaceSnapshot;
+  onChange: () => void;
+}): () => void {
+  const pollMs = opts?.pollMs ?? DEFAULT_POLL_MS;
+  const readNics = opts?.readNics ?? (() => os.networkInterfaces() as NetworkInterfaceSnapshot);
+  let last = networkFingerprint(readNics());
+  const timer = setInterval(() => {
+    const next = networkFingerprint(readNics());
+    if (next === last) return;
+    last = next;
+    opts?.onChange();
+  }, pollMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/src/main/services/pairRelayLookup.test.ts
+++ b/src/main/services/pairRelayLookup.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./pairStore', () => ({
+  saveRelayHostCache: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('resolveRelayConnectTarget', () => {
+  it('MagicDNS 独占且有缓存时跳过 lookup，标记钉 IP', async () => {
+    const { resolveRelayConnectTarget, seedRelayHostCache } = await import('./pairRelayLookup');
+    seedRelayHostCache({ 'enso-relay.j3.do': { address: '9.9.9.9', family: 4 } });
+    const lookup = vi.fn();
+    const target = await resolveRelayConnectTarget('enso-relay.j3.do', {
+      readNameservers: () => ['100.100.100.100'],
+      lookup,
+    });
+    expect(lookup).not.toHaveBeenCalled();
+    expect(target).toEqual({
+      hostname: 'enso-relay.j3.do',
+      resolved: { address: '9.9.9.9', family: 4 },
+      pin: true,
+    });
+  });
+
+  it('lookup 成功写入缓存；失败回落缓存并钉 IP', async () => {
+    const { saveRelayHostCache } = await import('./pairStore');
+    const { peekRelayHostCache, resolveRelayConnectTarget } = await import('./pairRelayLookup');
+    const target = await resolveRelayConnectTarget('enso-relay.j3.do', {
+      readNameservers: () => ['1.1.1.1'],
+      lookup: async () => ({ address: '1.2.3.4', family: 4 }),
+    });
+    expect(target).toEqual({
+      hostname: 'enso-relay.j3.do',
+      resolved: { address: '1.2.3.4', family: 4 },
+      pin: false,
+    });
+    expect(peekRelayHostCache().get('enso-relay.j3.do')).toEqual({
+      address: '1.2.3.4',
+      family: 4,
+    });
+    expect(saveRelayHostCache).toHaveBeenCalledWith(
+      new Map([['enso-relay.j3.do', { address: '1.2.3.4', family: 4 }]])
+    );
+
+    const fallback = await resolveRelayConnectTarget('enso-relay.j3.do', {
+      readNameservers: () => ['1.1.1.1'],
+      lookup: async () => {
+        throw new Error('ENOTFOUND');
+      },
+    });
+    expect(fallback).toEqual({
+      hostname: 'enso-relay.j3.do',
+      resolved: { address: '1.2.3.4', family: 4 },
+      pin: true,
+    });
+  });
+});

--- a/src/main/services/pairRelayLookup.ts
+++ b/src/main/services/pairRelayLookup.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from 'node:child_process';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { readFileSync } from 'node:fs';
+import {
+  isMagicDnsOnly,
+  parseLiteralHost,
+  parseRelayHostCache,
+  parseResolvConfNameservers,
+  parseScutilGlobalNameservers,
+  pickRelayConnectAddress,
+  type RelayHostAddress,
+  shouldSkipRelayLookup,
+  shouldUsePinnedRelaySocket,
+} from '@enso/pair';
+import { saveRelayHostCache } from './pairStore';
+
+export type RelayConnectTarget = {
+  hostname: string;
+  resolved: RelayHostAddress | null;
+  pin: boolean;
+};
+
+const cache = new Map<string, RelayHostAddress>();
+
+export function seedRelayHostCache(raw: unknown): void {
+  cache.clear();
+  for (const [hostname, address] of parseRelayHostCache(raw)) cache.set(hostname, address);
+}
+
+export function peekRelayHostCache(): Map<string, RelayHostAddress> {
+  return new Map(cache);
+}
+
+function rememberHost(hostname: string, resolved: RelayHostAddress): void {
+  cache.set(hostname, resolved);
+  saveRelayHostCache(cache);
+}
+
+export function readSystemNameservers(): string[] {
+  if (process.platform === 'darwin') {
+    try {
+      const output = execFileSync('scutil', ['--dns'], {
+        encoding: 'utf8',
+        timeout: 1_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const servers = parseScutilGlobalNameservers(output);
+      if (servers.length) return servers;
+    } catch {}
+  }
+  try {
+    return parseResolvConfNameservers(readFileSync('/etc/resolv.conf', 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+async function defaultLookup(hostname: string): Promise<RelayHostAddress> {
+  const result = await dnsLookup(hostname, { all: false });
+  return { address: result.address, family: result.family === 6 ? 6 : 4 };
+}
+
+export async function resolveRelayConnectTarget(
+  hostname: string,
+  deps?: {
+    readNameservers?: () => readonly string[];
+    lookup?: (hostname: string) => Promise<RelayHostAddress> | RelayHostAddress;
+  }
+): Promise<RelayConnectTarget> {
+  const literal = parseLiteralHost(hostname);
+  if (literal) return { hostname, resolved: literal, pin: false };
+
+  const cached = cache.get(hostname) ?? null;
+  const nameservers = (deps?.readNameservers ?? readSystemNameservers)();
+  const skipLookup = shouldSkipRelayLookup(cached !== null, isMagicDnsOnly(nameservers));
+  let lookupFailed = false;
+  let resolved: RelayHostAddress | null = null;
+  if (!skipLookup) {
+    try {
+      resolved = await (deps?.lookup ?? defaultLookup)(hostname);
+      if (resolved) rememberHost(hostname, resolved);
+    } catch {
+      lookupFailed = true;
+    }
+  }
+  const picked = pickRelayConnectAddress({
+    hostname,
+    cache: cached,
+    lookup: resolved,
+    skipLookup,
+  });
+  return {
+    hostname,
+    resolved: picked,
+    pin: shouldUsePinnedRelaySocket({
+      hostname,
+      resolved: picked,
+      skipLookup,
+      lookupFailed,
+    }),
+  };
+}

--- a/src/main/services/pairRelayOpen.test.ts
+++ b/src/main/services/pairRelayOpen.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { openPairRelayWebSocket } from './pairRelayOpen';
+
+describe('openPairRelayWebSocket', () => {
+  it('DNS 正常时走域名 socket，不钉 IP', async () => {
+    const openNamed = vi.fn(() => ({ kind: 'named' }) as unknown as WebSocket);
+    const openPinned = vi.fn(() => ({ kind: 'pinned' }) as unknown as WebSocket);
+    const ws = await openPairRelayWebSocket('wss://enso-relay.j3.do/v1/pair/p1?role=host', {
+      resolveTarget: async () => ({
+        hostname: 'enso-relay.j3.do',
+        resolved: { address: '1.2.3.4', family: 4 },
+        pin: false,
+      }),
+      openNamed,
+      openPinned,
+    });
+    expect(ws).toEqual({ kind: 'named' });
+    expect(openNamed).toHaveBeenCalledWith('wss://enso-relay.j3.do/v1/pair/p1?role=host');
+    expect(openPinned).not.toHaveBeenCalled();
+  });
+
+  it('DNS 挂了时钉 IP，并把原域名交给 pinned opener（SNI / Host）', async () => {
+    const openNamed = vi.fn(() => ({ kind: 'named' }) as unknown as WebSocket);
+    const openPinned = vi.fn(() => ({ kind: 'pinned' }) as unknown as WebSocket);
+    const ws = await openPairRelayWebSocket('wss://enso-relay.j3.do/v1/pair/p1?role=host', {
+      resolveTarget: async () => ({
+        hostname: 'enso-relay.j3.do',
+        resolved: { address: '1.2.3.4', family: 4 },
+        pin: true,
+      }),
+      openNamed,
+      openPinned,
+    });
+    expect(ws).toEqual({ kind: 'pinned' });
+    expect(openPinned).toHaveBeenCalledWith(
+      'wss://1.2.3.4/v1/pair/p1?role=host',
+      'enso-relay.j3.do',
+      ''
+    );
+    expect(openNamed).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/pairRelayOpen.ts
+++ b/src/main/services/pairRelayOpen.ts
@@ -1,0 +1,43 @@
+import { Agent, WebSocket as UndiciWebSocket } from 'undici';
+import { type RelayConnectTarget, resolveRelayConnectTarget } from './pairRelayLookup';
+import { buildPinnedRelaySocketUrl } from './pairRelaySocket';
+
+export async function openPairRelayWebSocket(
+  url: string,
+  deps?: {
+    resolveTarget?: (hostname: string) => Promise<RelayConnectTarget>;
+    openNamed?: (url: string) => WebSocket;
+    openPinned?: (url: string, servername: string, port: string) => WebSocket;
+  }
+): Promise<WebSocket> {
+  const parsed = new URL(url);
+  const target = await (deps?.resolveTarget ?? resolveRelayConnectTarget)(parsed.hostname);
+  if (target.pin && target.resolved) {
+    const pinned = buildPinnedRelaySocketUrl(parsed, target.resolved);
+    return (deps?.openPinned ?? defaultOpenPinned)(pinned.href, target.hostname, parsed.port);
+  }
+  return (deps?.openNamed ?? defaultOpenNamed)(url);
+}
+
+function defaultOpenNamed(url: string): WebSocket {
+  return new WebSocket(url);
+}
+
+/** 钉 IP 时必须自带 SNI / Host，否则证书对不上。走 undici，避开 Chromium 按 IP 校验。 */
+function defaultOpenPinned(url: string, servername: string, _port: string): WebSocket {
+  const dispatcher = new Agent({
+    connect: { servername },
+    headersTimeout: 0,
+    bodyTimeout: 0,
+  });
+  const ws = new UndiciWebSocket(url, {
+    dispatcher,
+    headers: { host: servername },
+  });
+  const closeAgent = (): void => {
+    void dispatcher.close();
+  };
+  ws.addEventListener('close', closeAgent);
+  ws.addEventListener('error', closeAgent);
+  return ws as unknown as WebSocket;
+}

--- a/src/main/services/pairRelaySocket.test.ts
+++ b/src/main/services/pairRelaySocket.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildPinnedRelaySocketUrl, relaySocketConnectHost } from './pairRelaySocket';
+
+describe('relaySocketConnectHost', () => {
+  it('钉 IPv4 时用字面量，IPv6 加方括号', () => {
+    expect(relaySocketConnectHost('enso-relay.j3.do', { address: '1.2.3.4', family: 4 })).toBe(
+      '1.2.3.4'
+    );
+    expect(relaySocketConnectHost('enso-relay.j3.do', { address: '2001:db8::1', family: 6 })).toBe(
+      '[2001:db8::1]'
+    );
+  });
+
+  it('没解析结果时仍用域名', () => {
+    expect(relaySocketConnectHost('enso-relay.j3.do', null)).toBe('enso-relay.j3.do');
+  });
+});
+
+describe('buildPinnedRelaySocketUrl', () => {
+  it('把 hostname 换成钉住的 IP，Host 头仍是原域名', () => {
+    const url = new URL('wss://enso-relay.j3.do/v1/pair/p1?role=host&token=t');
+    const next = buildPinnedRelaySocketUrl(url, { address: '1.2.3.4', family: 4 });
+    expect(next.href).toBe('wss://1.2.3.4/v1/pair/p1?role=host&token=t');
+    expect(next.hostname).toBe('1.2.3.4');
+  });
+});

--- a/src/main/services/pairRelaySocket.ts
+++ b/src/main/services/pairRelaySocket.ts
@@ -1,0 +1,15 @@
+import type { RelayHostAddress } from '@enso/pair';
+
+export function relaySocketConnectHost(
+  hostname: string,
+  resolved: RelayHostAddress | null
+): string {
+  if (!resolved) return hostname;
+  return resolved.family === 6 ? `[${resolved.address}]` : resolved.address;
+}
+
+export function buildPinnedRelaySocketUrl(url: URL, resolved: RelayHostAddress): URL {
+  const next = new URL(url);
+  next.hostname = relaySocketConnectHost(url.hostname, resolved);
+  return next;
+}

--- a/src/main/services/pairStore.test.ts
+++ b/src/main/services/pairStore.test.ts
@@ -96,3 +96,25 @@ describe('中继地址持久化', () => {
     expect(loadDevices()).toEqual([]);
   });
 });
+
+describe('中继 IP 缓存', () => {
+  it('往返合法记录，丢掉脏条目', async () => {
+    const { loadRelayHostCache, saveRelayHostCache } = await store();
+    saveRelayHostCache(
+      new Map([
+        ['enso-relay.j3.do', { address: '1.2.3.4', family: 4 }],
+        ['bad', { address: 'nope', family: 4 }],
+      ])
+    );
+    expect(loadRelayHostCache()).toEqual({
+      'enso-relay.j3.do': { address: '1.2.3.4', family: 4 },
+    });
+  });
+
+  it('文件损坏或缺失按空缓存处理', async () => {
+    const { loadRelayHostCache } = await store();
+    expect(loadRelayHostCache()).toEqual({});
+    writeFileSync(path.join(dir, 'relay-host-cache.json'), '{ not json');
+    expect(loadRelayHostCache()).toEqual({});
+  });
+});

--- a/src/main/services/pairStore.ts
+++ b/src/main/services/pairStore.ts
@@ -1,6 +1,11 @@
 import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import type { PairedDevice } from '@enso/pair';
+import {
+  type PairedDevice,
+  parseRelayHostCache,
+  type RelayHostAddress,
+  serializeRelayHostCache,
+} from '@enso/pair';
 import { app, safeStorage } from 'electron';
 
 /**
@@ -107,5 +112,30 @@ export function saveRelayUrl(relayUrl: string | null): void {
     renameSync(tmp, file);
   } catch (error) {
     console.warn('[pair] save relay url failed', error);
+  }
+}
+
+function relayHostCachePath(): string {
+  return path.join(app.getPath('userData'), 'relay-host-cache.json');
+}
+
+export function loadRelayHostCache(): Record<string, RelayHostAddress> {
+  try {
+    const file = relayHostCachePath();
+    if (!existsSync(file)) return {};
+    return Object.fromEntries(parseRelayHostCache(JSON.parse(readFileSync(file, 'utf-8'))));
+  } catch {
+    return {};
+  }
+}
+
+export function saveRelayHostCache(cache: Map<string, RelayHostAddress>): void {
+  try {
+    const file = relayHostCachePath();
+    const tmp = `${file}.tmp`;
+    writeFileSync(tmp, serializeRelayHostCache(parseRelayHostCache(Object.fromEntries(cache))));
+    renameSync(tmp, file);
+  } catch (error) {
+    console.warn('[pair] save relay host cache failed', error);
   }
 }


### PR DESCRIPTION
## 背景
Tailscale / VPN 掉线后，系统 DNS 常只剩 MagicDNS。中继 hostname 解析失败时，桌面和手机会停在半开 WebSocket 上：close 不来，心跳也探不醒。

## 改动
- 成功解析写入 `relay-host-cache.json`；MagicDNS 独占时跳过 lookup，钉上次 IP
- 钉 IP 走 undici WebSocket，自带 SNI / Host，避开 Chromium 按 IP 验证书
- 网卡指纹轮询到变化、以及手机 `online`：拆半开链后立即重连
- 睡眠唤醒 / 回前台只探活，不主动拆活链
- 异步开 socket 用 generation 丢弃过期结果

## 测试
`pnpm exec vitest run packages/pair/src/revive.test.ts src/main/services/pairRelayLookup.test.ts src/main/services/pairRelayOpen.test.ts src/main/services/pairRelaySocket.test.ts src/main/services/pairNetworkWatch.test.ts src/main/services/pairStore.test.ts`