### PR TITLE
feat(agent): 新增隔离沙箱 exec，默认启用

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,6 +13,8 @@ files:
     to: node_modules/@rahularya01/pi-cursor
   - from: node_modules/@bufbuild/protobuf
     to: node_modules/@bufbuild/protobuf
+  - from: node_modules/quickjs-wasi
+    to: node_modules/quickjs-wasi
 mac:
   category: public.app-category.developer-tools
   target:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "node-datachannel": "^0.33.2",
     "node-pty": "^1.1.0",
     "qrcode": "^1.5.4",
+    "quickjs-wasi": "3.6.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
+      quickjs-wasi:
+        specifier: 3.6.0
+        version: 3.6.0
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -4295,6 +4298,9 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  quickjs-wasi@3.6.0:
+    resolution: {integrity: sha512-/CNzMq42B8ThzUpzjLSF8K50ntVLV3RREyT8zr4wHaP2CZSHFhPkqg3E1GULmTerehf8Bo+UguQ+4LoOMCTC6A==}
 
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
@@ -9270,6 +9276,8 @@ snapshots:
       side-channel: 1.1.1
 
   quick-lru@5.1.1: {}
+
+  quickjs-wasi@3.6.0: {}
 
   range-parser@1.3.0: {}
 

--- a/src/agent/builtinOccupancy.ts
+++ b/src/agent/builtinOccupancy.ts
@@ -4,6 +4,7 @@ import type { AgentTypeSpawnConfig, SubagentModelOption } from '@shared/types/ag
 import { AskManager, createAskTool } from './ask';
 import { createTaskTools } from './backgroundTasks';
 import { createCoworkerTool } from './coworker';
+import { createIsolatedSandboxTool } from './isolatedSandbox';
 import { createSubagentTool } from './subagent';
 import { createTodoTool } from './todo';
 import { BrowserInvoker, createBrowserTools } from './tools/browser';
@@ -80,5 +81,6 @@ export function snapshotBuiltinOccupancyTools(input?: {
       stop: () => false,
       knownIds: () => [],
     } as never).map(fields),
+    isolated_sandbox: [fields(createIsolatedSandboxTool({ getTools: () => [] }))],
   };
 }

--- a/src/agent/isolatedSandbox.test.ts
+++ b/src/agent/isolatedSandbox.test.ts
@@ -1,0 +1,354 @@
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { describe, expect, it } from 'vitest';
+import { computeFileHash, formatHashlineHeader } from './hashline/format';
+import { InMemorySnapshotStore } from './hashline/snapshots';
+import { withHashlineRead } from './hashline/withRead';
+import {
+  createIsolatedSandboxTool,
+  guestCallableName,
+  looksLikeShellCommand,
+} from './isolatedSandbox';
+
+function mockTool(name: string, execute: ToolDefinition['execute']): ToolDefinition {
+  return {
+    name,
+    description: name,
+    parameters: { type: 'object' },
+    execute,
+  } as unknown as ToolDefinition;
+}
+
+async function run(
+  code: string,
+  tools: ToolDefinition[] = [],
+  store?: Map<string, unknown>
+): Promise<{ text: string; details: Record<string, unknown> }> {
+  const tool = createIsolatedSandboxTool({ getTools: () => tools, store });
+  const result = await tool.execute('exec-1', { code }, undefined, undefined, {} as never);
+  const first = result.content[0];
+  if (first?.type !== 'text') throw new Error('expected text');
+  return {
+    text: first.text,
+    details: (result.details ?? {}) as Record<string, unknown>,
+  };
+}
+
+describe('looksLikeShellCommand', () => {
+  it('拒绝可识别的 shell，放过 JS', () => {
+    expect(looksLikeShellCommand('ls -la')).toBe(true);
+    expect(looksLikeShellCommand('git status')).toBe(true);
+    expect(looksLikeShellCommand('const x = 1; return x')).toBe(false);
+    expect(looksLikeShellCommand('await read({ path: "a.ts" })')).toBe(false);
+    expect(looksLikeShellCommand('ls({ path: "." })')).toBe(false);
+  });
+});
+
+describe('createIsolatedSandboxTool', () => {
+  it('prompt 写明只要聚合结果才用 exec，探索/并行读不要进沙箱', () => {
+    const tool = createIsolatedSandboxTool({ getTools: () => [] });
+    const text = [tool.description, tool.promptSnippet, ...(tool.promptGuidelines ?? [])].join(
+      '\n'
+    );
+    expect(text).toMatch(/3\+ similar read\/grep\/find/i);
+    expect(text).toMatch(/No console/i);
+    expect(text).toMatch(/isError: true/i);
+    expect(text).toMatch(/listTools/i);
+  });
+
+  it('guestCallableName 把 MCP 名收成合法标识符且不撞名', () => {
+    const taken = new Set<string>();
+    expect(guestCallableName('mcp.foo-bar', taken)).toBe('mcp_foo_bar');
+    expect(guestCallableName('mcp.foo-bar', taken)).toBe('mcp_foo_bar_2');
+    expect(guestCallableName('123watch', taken)).toBe('tool_123watch');
+    taken.add('JSON');
+    expect(guestCallableName('JSON', taken)).toBe('JSON_2');
+  });
+
+  it('在 QuickJS 里求值，guest 没有 fs/require', async () => {
+    const result = await run(`
+      if (typeof require !== "undefined") throw new Error("require leaked");
+      if (typeof process !== "undefined") throw new Error("process leaked");
+      return 1 + 2;
+    `);
+    expect(result.details.status).toBe('completed');
+    expect(result.details.value).toBe(3);
+  });
+
+  it('guest 可调用写工具，走传入的 execute', async () => {
+    const writes: unknown[] = [];
+    const write = mockTool('write', async (_id, params) => {
+      writes.push(params);
+      return { content: [{ type: 'text', text: 'ok' }], details: { ok: true } };
+    });
+    const result = await run(
+      `
+        const out = await write({ path: "a.ts", content: "x" });
+        return out.details;
+      `,
+      [write]
+    );
+    expect(writes).toEqual([{ path: 'a.ts', content: 'x' }]);
+    expect(result.details.value).toEqual({ ok: true });
+  });
+
+  it('写工具失败可 catch，先前副作用不回滚', async () => {
+    const writes: string[] = [];
+    const write = mockTool('write', async (_id, params) => {
+      const path = (params as { path: string }).path;
+      writes.push(path);
+      if (path === 'b.ts') throw new Error('disk full');
+      return { content: [{ type: 'text', text: 'ok' }], details: {} };
+    });
+    const result = await run(
+      `
+        const a = await write({ path: "a.ts", content: "1" });
+        const b = await write({ path: "b.ts", content: "2" });
+        return { a: a.isError, b: b.isError, bText: b.content };
+      `,
+      [write]
+    );
+    expect(writes).toEqual(['a.ts', 'b.ts']);
+    expect(result.details.value).toEqual({
+      a: false,
+      b: true,
+      bText: 'disk full',
+    });
+  });
+
+  it('拒绝递归 exec 和 shell 形态输入', async () => {
+    const nested = mockTool('exec', async () => {
+      throw new Error('should not run');
+    });
+    const recursive = await run('await exec({ code: "return 1" })', [nested]);
+    expect(recursive.details.status).toBe('failed');
+    expect(recursive.text).toMatch(/not defined|not available/i);
+
+    await expect(run('ls -la src')).rejects.toThrow(/javascript/i);
+  });
+
+  it('Promise.all 并行调两个工具', async () => {
+    let live = 0;
+    let maxLive = 0;
+    const read = mockTool('read', async (_id, params) => {
+      live += 1;
+      maxLive = Math.max(maxLive, live);
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      live -= 1;
+      return {
+        content: [{ type: 'text', text: String((params as { path: string }).path) }],
+        details: {},
+      };
+    });
+    const result = await run(
+      `
+        const [a, b] = await Promise.all([
+          read({ path: "a.ts" }),
+          read({ path: "b.ts" }),
+        ]);
+        return [a.content, b.content];
+      `,
+      [read]
+    );
+    expect(maxLive).toBe(2);
+    expect(result.details.value).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('工具失败 resolve 为 isError，不拖垮 Promise.all', async () => {
+    const read = mockTool('read', async (_id, params) => {
+      const path = (params as { path: string }).path;
+      if (path === 'missing') throw new Error('ENOENT');
+      return { content: [{ type: 'text', text: 'ok' }], details: {} };
+    });
+    const result = await run(
+      `
+        const [ok, bad] = await Promise.all([
+          read({ path: "a.ts" }),
+          read({ path: "missing" }),
+        ]);
+        return { ok: ok.isError, bad: bad.isError, text: bad.content };
+      `,
+      [read]
+    );
+    expect(result.details.status).toBe('completed');
+    expect(result.details.value).toEqual({ ok: false, bad: true, text: 'ENOENT' });
+  });
+
+  it('store/load 跨两次 exec 活着', async () => {
+    const store = new Map<string, unknown>();
+    await run(`store("n", 3); return load("n");`, [], store);
+    const second = await run(`return load("n") + 1;`, [], store);
+    expect(second.details.value).toBe(4);
+  });
+
+  it('连字符工具名可在 guest 里当标识符调用', async () => {
+    const calls: unknown[] = [];
+    const tool = mockTool('mcp.list-shipments', async (_id, params) => {
+      calls.push(params);
+      return { content: [{ type: 'text', text: 'ok' }], details: { rows: [1] } };
+    });
+    const result = await run(`return (await mcp_list_shipments({ paid: false })).details;`, [tool]);
+    expect(calls).toEqual([{ paid: false }]);
+    expect(result.details.value).toEqual({ rows: [1] });
+  });
+
+  it('write 内容含 import 语句不被预检误杀', async () => {
+    const writes: unknown[] = [];
+    const write = mockTool('write', async (_id, params) => {
+      writes.push(params);
+      return { content: [{ type: 'text', text: 'ok' }], details: {} };
+    });
+    const result = await run(
+      `await write({ path: "a.ts", content: "import { x } from './x'\\n" }); return "ok";`,
+      [write]
+    );
+    expect(result.details.status).toBe('completed');
+    expect(writes).toHaveLength(1);
+  });
+
+  it('store(undefined) 之后 load 得到 undefined', async () => {
+    const store = new Map<string, unknown>();
+    const result = await run(`store("k", undefined); return load("k");`, [], store);
+    expect(result.details.value).toBeUndefined();
+  });
+
+  it('subagent/coworker 不注入 guest，catalog 也搜不到', async () => {
+    const sub = mockTool('subagent', async () => {
+      throw new Error('should not run');
+    });
+    const cow = mockTool('coworker', async () => {
+      throw new Error('should not run');
+    });
+    const ping = mockTool('read', async () => ({
+      content: [{ type: 'text', text: 'ok' }],
+      details: {},
+    }));
+    const result = await run(
+      `
+        return {
+          sub: typeof subagent,
+          cow: typeof coworker,
+          hits: (await catalog.search("sub")).length,
+          names: catalog.all().length,
+        };
+      `,
+      [sub, cow, ping]
+    );
+    expect(result.details.value).toEqual({
+      sub: 'undefined',
+      cow: 'undefined',
+      hits: 0,
+      names: 1,
+    });
+  });
+
+  it('hashline 包装的 read 把文件头和行号带回 guest', async () => {
+    const path = '/tmp/a.ts';
+    const body = 'alpha\nbeta\n';
+    const store = new InMemorySnapshotStore();
+    const raw = mockTool('read', async () => ({
+      content: [{ type: 'text', text: body }],
+      details: { raw: true },
+    }));
+    const read = withHashlineRead(raw, store) as unknown as ToolDefinition;
+    const result = await run(`return (await read({ path: ${JSON.stringify(path)} })).content;`, [
+      read,
+    ]);
+    const content = result.details.value;
+    expect(typeof content).toBe('string');
+    expect(content).toContain(formatHashlineHeader(path, computeFileHash(body)));
+    expect(content).toContain('1:alpha');
+    expect(content).toContain('2:beta');
+  });
+
+  it('Promise.all 超出预算在 enqueue 时失败，且不执行已入队调用', async () => {
+    let ran = 0;
+    const read = mockTool('read', async () => {
+      ran += 1;
+      return {
+        content: [{ type: 'text', text: 'ok' }],
+        details: {},
+      };
+    });
+    const result = await run(
+      `
+        await Promise.all(Array.from({ length: 70 }, (_, i) => read({ path: String(i) })));
+        return "ok";
+      `,
+      [read]
+    );
+    expect(result.details.status).toBe('failed');
+    expect(result.text).toMatch(/budget/i);
+    expect(ran).toBe(0);
+  });
+
+  it('先 await 一次再超预算，只执行第一次调用', async () => {
+    let ran = 0;
+    const read = mockTool('read', async () => {
+      ran += 1;
+      return {
+        content: [{ type: 'text', text: 'ok' }],
+        details: {},
+      };
+    });
+    const result = await run(
+      `
+        await read({ path: "first" });
+        await Promise.all(Array.from({ length: 70 }, (_, i) => read({ path: String(i) })));
+        return "ok";
+      `,
+      [read]
+    );
+    expect(result.details.status).toBe('failed');
+    expect(result.text).toMatch(/budget/i);
+    expect(ran).toBe(1);
+  });
+
+  it('console.log 提示用 return，listTools 列出可调用名', async () => {
+    const read = mockTool('read', async () => ({
+      content: [{ type: 'text', text: 'ok' }],
+      details: {},
+    }));
+    const listed = await run(`return listTools();`, [read]);
+    expect(listed.details.value).toEqual([{ name: 'read', tool: 'read' }]);
+    const logged = await run(`console.log("hi"); return 1;`, [read]);
+    expect(logged.details.status).toBe('failed');
+    expect(logged.text).toMatch(/No console; use return/i);
+  });
+
+  it('超大 return 截断并给出缩小返回值的提示', async () => {
+    const result = await run(`return "x".repeat(20000);`);
+    expect(result.details.truncated).toBe(true);
+    expect(String(result.details.hint)).toMatch(/value too large/i);
+    expect(Buffer.byteLength(result.text, 'utf8')).toBeLessThanOrEqual(8 * 1024);
+  });
+
+  it('calls + 返回值一起超 8KB 时仍守住上限', async () => {
+    const read = mockTool('read', async (_id, params) => ({
+      content: [{ type: 'text', text: 'ok' }],
+      details: { path: String((params as { path: string }).path) },
+    }));
+    const result = await run(
+      `
+        const hits = await Promise.all(
+          Array.from({ length: 40 }, (_, i) => read({ path: "p".repeat(80) + String(i) }))
+        );
+        return { n: hits.length, blob: "y".repeat(6000) };
+      `,
+      [read]
+    );
+    expect(result.details.status).toBe('completed');
+    expect(result.details.truncated).toBe(true);
+    expect(Buffer.byteLength(result.text, 'utf8')).toBeLessThanOrEqual(8 * 1024);
+    expect(JSON.parse(result.text).truncated).toBe(true);
+  });
+
+  it('MCP 原名 ReferenceError 会提示 did you mean', async () => {
+    const search = mockTool('mcp__semble__search', async () => ({
+      content: [{ type: 'text', text: 'ok' }],
+      details: {},
+    }));
+    const result = await run(`return await mcp__semble__search({ query: "x" });`, [search]);
+    expect(result.details.status).toBe('failed');
+    expect(result.text).toMatch(/did you mean mcp_semble_search/i);
+  });
+});

--- a/src/agent/isolatedSandbox.ts
+++ b/src/agent/isolatedSandbox.ts
@@ -1,0 +1,597 @@
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { JSException, type JSValueHandle, QuickJS } from 'quickjs-wasi';
+
+const require = createRequire(import.meta.url);
+let wasmModule: Promise<WebAssembly.Module> | undefined;
+
+function loadQuickJsWasm(): Promise<WebAssembly.Module> {
+  wasmModule ??= readFile(require.resolve('quickjs-wasi/quickjs.wasm')).then((bytes) =>
+    WebAssembly.compile(bytes)
+  );
+  return wasmModule;
+}
+
+const TIMEOUT_MS = 30_000;
+const MEMORY_LIMIT_BYTES = 32 * 1024 * 1024;
+const MAX_TOOL_CALLS = 64;
+const MAX_INFLIGHT = 16;
+const MAX_OUTPUT_BYTES = 8 * 1024;
+
+const FORBIDDEN_GUEST_TOOLS = new Set([
+  'exec',
+  'wait',
+  'subagent',
+  'coworker',
+  'message_coworker',
+  'message_main_agent',
+  'explore_mark',
+  'explore_fold',
+  'goal_complete',
+  'goal_blocked',
+  'goal_wait',
+  'ask_user',
+  'todo',
+  'task_output',
+  'task_stop',
+]);
+
+const SHELL_HEAD =
+  /^(cd|ls|git|npm|pnpm|yarn|cat|echo|rm|mkdir|chmod|sudo|curl|wget|python|pip|brew|head|tail|grep|rg)\b/;
+
+export interface IsolatedSandboxToolOptions {
+  getTools: () => readonly ToolDefinition[];
+  /** 会话级 JSON 仓，跨多次 exec 的 store/load */
+  store?: Map<string, unknown>;
+}
+
+interface HostCall {
+  id: string;
+  name: string;
+  args: unknown;
+}
+
+export function looksLikeShellCommand(code: string): boolean {
+  const trimmed = code.trim();
+  if (!trimmed) return false;
+  if (/\b(await|const|let|var|function|return)\b/.test(trimmed) || trimmed.includes('=>')) {
+    return false;
+  }
+  if (/^\w+\(/.test(trimmed)) return false;
+  return SHELL_HEAD.test(trimmed);
+}
+
+function jsonClone(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value)) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+const RESERVED_CALLABLES = new Set([
+  'catalog',
+  'store',
+  'load',
+  'tools',
+  'JSON',
+  'Promise',
+  'Object',
+  'Array',
+  'Map',
+  'Set',
+  'Error',
+  'String',
+  'Math',
+  'Date',
+  'console',
+  'Function',
+  'undefined',
+  ...FORBIDDEN_GUEST_TOOLS,
+]);
+
+export function guestCallableName(name: string, taken: Set<string>): string {
+  let base = name
+    .replace(/[^A-Za-z0-9_$]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '');
+  if (!base) base = 'tool';
+  if (!/^[A-Za-z_$]/.test(base)) base = `tool_${base}`;
+  let candidate = base;
+  let suffix = 2;
+  while (taken.has(candidate)) candidate = `${base}_${suffix++}`;
+  taken.add(candidate);
+  return candidate;
+}
+
+function textOf(result: { content?: Array<{ type?: string; text?: string }> }): string {
+  return (result.content ?? [])
+    .filter((part) => part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text)
+    .join('\n');
+}
+
+function guestResult(result: {
+  content?: Array<{ type?: string; text?: string }>;
+  details?: unknown;
+  isError?: boolean;
+}): unknown {
+  return jsonClone({
+    content: textOf(result),
+    details: result.details,
+    isError: result.isError === true,
+  });
+}
+
+function suggestCallable(missing: string, names: readonly string[]): string | undefined {
+  const normalized = missing.replace(/-/g, '_').replace(/_+/g, '_');
+  if (names.includes(normalized) && normalized !== missing) return normalized;
+  return names.find((name) => name === normalized || name.endsWith(`_${normalized}`));
+}
+
+function withDidYouMean(message: string, names: readonly string[]): string {
+  const match = /([A-Za-z_$][\w$]*)\s+is not defined/.exec(message);
+  const missing = match?.[1];
+  if (!missing) return message;
+  const hint = suggestCallable(missing, names);
+  const rule = 'Tool names replace "-" and "__" with "_" (mcp__foo__bar → mcp_foo_bar).';
+  if (hint) return `${message} Did you mean ${hint}? ${rule}`;
+  if (missing.includes('mcp') || missing.includes('__')) return `${message} ${rule}`;
+  return message;
+}
+
+function dropQueued(
+  queue: HostCall[],
+  calls: Array<{ name: string; ok: boolean; error?: string; summary?: string }>
+): void {
+  while (queue.length > 0) {
+    const job = queue.shift();
+    if (!job) break;
+    const summary = callSummary(job.args);
+    calls.push({
+      name: job.name,
+      ok: false,
+      error: 'dropped',
+      ...(summary ? { summary } : {}),
+    });
+  }
+}
+
+function callSummary(args: unknown): string | undefined {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return undefined;
+  const record = args as Record<string, unknown>;
+  const value = record.path ?? record.command ?? record.pattern ?? record.query;
+  return typeof value === 'string' && value ? value.slice(0, 80) : undefined;
+}
+
+function slimCalls(calls: Array<{ name: string; ok: boolean; error?: string; summary?: string }>) {
+  return calls.map(({ summary: _summary, ...rest }) => rest);
+}
+
+function packGuestOutput(details: {
+  status: 'completed' | 'failed';
+  value?: unknown;
+  error?: string;
+  calls: unknown[];
+}): { text: string; details: Record<string, unknown> } {
+  const rawValue =
+    typeof details.value === 'string' ? details.value : (JSON.stringify(details.value) ?? '');
+  let value: unknown = details.value;
+  let error = details.error;
+  let calls = details.calls.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+    const rec = entry as Record<string, unknown>;
+    if (typeof rec.name !== 'string' || !rec.name) return [];
+    return [
+      {
+        name: rec.name,
+        ok: rec.ok === true,
+        ...(typeof rec.error === 'string' ? { error: rec.error } : {}),
+        ...(typeof rec.summary === 'string' ? { summary: rec.summary } : {}),
+      },
+    ];
+  });
+  let hint: string | undefined;
+  let omittedCalls = 0;
+
+  const build = () => {
+    const packed: Record<string, unknown> = { status: details.status, calls };
+    if (details.status === 'completed') packed.value = value;
+    if (details.status === 'failed') packed.error = error;
+    if (hint) {
+      packed.truncated = true;
+      packed.hint = hint;
+    }
+    if (omittedCalls > 0) packed.omittedCalls = omittedCalls;
+    const text = JSON.stringify(packed);
+    return { text, details: packed, bytes: Buffer.byteLength(text, 'utf8') };
+  };
+
+  let out = build();
+  if (out.bytes <= MAX_OUTPUT_BYTES) return { text: out.text, details: out.details };
+
+  hint = `value too large (${rawValue.length} chars); write to a file or narrow the return`;
+  let head = rawValue;
+  value = `${head}…`;
+  out = build();
+  while (head.length > 0 && out.bytes > MAX_OUTPUT_BYTES) {
+    head = head.slice(0, Math.max(0, Math.floor(head.length * 0.8)));
+    value = `${head}…`;
+    out = build();
+  }
+  if (out.bytes <= MAX_OUTPUT_BYTES) return { text: out.text, details: out.details };
+
+  hint = 'output too large; write to a file or narrow the return';
+  calls = slimCalls(calls);
+  out = build();
+  if (out.bytes <= MAX_OUTPUT_BYTES) return { text: out.text, details: out.details };
+
+  while (calls.length > 0 && out.bytes > MAX_OUTPUT_BYTES) {
+    const drop = Math.max(1, Math.ceil(calls.length * 0.2));
+    omittedCalls += drop;
+    calls = calls.slice(0, Math.max(0, calls.length - drop));
+    out = build();
+  }
+  if (out.bytes <= MAX_OUTPUT_BYTES) return { text: out.text, details: out.details };
+
+  value = '';
+  error = error?.slice(0, 200);
+  omittedCalls += calls.length;
+  calls = [];
+  out = build();
+  return { text: out.text, details: out.details };
+}
+
+function failed(message: string, extra?: Record<string, unknown>) {
+  const packed = packGuestOutput({
+    status: 'failed',
+    error: message,
+    calls: Array.isArray(extra?.calls) ? extra.calls : [],
+  });
+  return {
+    content: [{ type: 'text' as const, text: packed.text }],
+    details: packed.details,
+    isError: true as const,
+  };
+}
+
+export function createIsolatedSandboxTool(options: IsolatedSandboxToolOptions): ToolDefinition {
+  return {
+    name: 'exec',
+    label: 'Isolated sandbox',
+    description:
+      'If you are about to make 3+ similar read/grep/find calls and only need the aggregate, use exec instead of repeating those tools. ' +
+      'Example:\n' +
+      'const files = (await find({pattern:"src/**/*.ts"})).content.split("\\n").filter(Boolean);\n' +
+      'const hits = await Promise.all(files.map(f => grep({pattern:"TODO", path:f})));\n' +
+      'return hits.filter(h => h.content).length;\n' +
+      'Each tool returns { content, details?, isError }. No console/fetch/setTimeout/URL/TextEncoder — use return. ' +
+      'Tool failures resolve as { content, isError: true } and do not reject — check isError, do not rely on throw. ' +
+      'A JavaScript exception still fails the whole cell. ' +
+      'Hashline headers require the Hashline setting, same as top-level read. ' +
+      'Tool names: "-" and "__" become "_": mcp__semble__search → mcp_semble_search. ' +
+      'catalog.list() / listTools() lists callable names. store()/load() last for this live session. Not a shell.',
+    promptSnippet:
+      'exec: 3+ similar read/grep/find when you only need the aggregate — not for exploring. ' +
+      'No console; return the value. Uncaught throw fails the cell. MCP names collapse __ and - to _.',
+    promptGuidelines: [
+      'If you are about to make 3+ similar read/grep/find calls and only need the aggregate, use exec instead.',
+      'No console.log — there is no console, fetch, setTimeout, URL, TextEncoder, or structuredClone. Use return.',
+      'Tool failures resolve with isError: true and do not throw. A JS exception still fails the whole cell.',
+      'Each nested tool returns { content: string, details?: unknown, isError: boolean }. Do not treat the result as a raw string.',
+      'Hashline [path#tag] headers require the Hashline setting, same as top-level read/grep.',
+      'Tool names replace "-" and "__" with "_": mcp__semble__search → mcp_semble_search. Use catalog.list() or listTools() for names.',
+      'store(key, value) / load(key) keep JSON across exec cells until this session unloads; they do not survive resume.',
+      'exec is deterministic code with no LLM inside. Use subagent when each item needs judgment.',
+    ],
+    parameters: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description: 'JavaScript source. Top-level await and return work.',
+        },
+        command: { type: 'string', description: 'Deprecated alias of code. Not a shell command.' },
+      },
+      additionalProperties: false,
+    } as unknown as ToolDefinition['parameters'],
+    async execute(toolCallId, params, signal, _onUpdate, ctx) {
+      const record = (params ?? {}) as Record<string, unknown>;
+      const code = [record.code, record.command].find((value) => typeof value === 'string') as
+        | string
+        | undefined;
+      if (!code?.trim()) throw new Error('exec requires code');
+      if (looksLikeShellCommand(code)) {
+        throw new Error('exec expects JavaScript, not a shell command. Use bash for shell.');
+      }
+      const catalog = options
+        .getTools()
+        .filter(
+          (tool) => tool.name && !FORBIDDEN_GUEST_TOOLS.has(tool.name) && tool.name !== 'exec'
+        );
+      return runGuest({
+        code,
+        catalog,
+        parentCallId: toolCallId,
+        signal,
+        ctx,
+        store: options.store ?? new Map(),
+      });
+    },
+  };
+}
+
+async function runGuest(input: {
+  code: string;
+  catalog: readonly ToolDefinition[];
+  parentCallId: string;
+  signal?: AbortSignal;
+  ctx: unknown;
+  store: Map<string, unknown>;
+}) {
+  const taken = new Set(RESERVED_CALLABLES);
+  const aliases = input.catalog.map((tool) => ({
+    callable: guestCallableName(tool.name, taken),
+    tool: tool.name,
+  }));
+  const names = aliases.map((entry) => entry.callable);
+  const listing = aliases.map((entry) => ({ name: entry.callable, tool: entry.tool }));
+  const tools = new Map(input.catalog.map((tool) => [tool.name, tool]));
+  const queue: HostCall[] = [];
+  const calls: Array<{ name: string; ok: boolean; error?: string; summary?: string }> = [];
+  let nextId = 0;
+  let admitted = 0;
+  const started = performance.now();
+  let pausedMs = 0;
+  let pauseStarted = 0;
+  let hostInflight = 0;
+  const elapsed = () =>
+    performance.now() -
+    started -
+    pausedMs -
+    (pauseStarted === 0 ? 0 : performance.now() - pauseStarted);
+
+  const vm = await QuickJS.create({
+    wasm: await loadQuickJsWasm(),
+    memoryLimit: MEMORY_LIMIT_BYTES,
+    interruptHandler: () => elapsed() > TIMEOUT_MS || Boolean(input.signal?.aborted),
+  });
+
+  const pause = () => {
+    if (hostInflight++ === 0) pauseStarted = performance.now();
+  };
+  const resume = () => {
+    if (hostInflight === 0) return;
+    hostInflight -= 1;
+    if (hostInflight > 0) return;
+    if (pauseStarted === 0) return;
+    pausedMs += performance.now() - pauseStarted;
+    pauseStarted = 0;
+  };
+
+  try {
+    vm.newFunction('__ensoEnqueue', (nameHandle: JSValueHandle, argsHandle: JSValueHandle) => {
+      const name = nameHandle.toString();
+      if (FORBIDDEN_GUEST_TOOLS.has(name) || name === 'exec') {
+        throw new Error(`Tool "${name}" is not available in the isolated sandbox`);
+      }
+      if (!tools.has(name))
+        throw new Error(`Tool "${name}" is not available in the isolated sandbox`);
+      if (admitted >= MAX_TOOL_CALLS) throw new Error('isolated sandbox tool call budget exceeded');
+      admitted += 1;
+      let args: unknown = {};
+      try {
+        args = JSON.parse(argsHandle.toString()) as unknown;
+      } catch {
+        args = {};
+      }
+      const id = String(++nextId);
+      queue.push({ id, name, args });
+      return vm.newString(id);
+    }).consume((handle) => vm.global.setProp('__ensoEnqueue', handle));
+    vm.newFunction('__ensoStore', (keyHandle: JSValueHandle, jsonHandle: JSValueHandle) => {
+      const key = keyHandle.toString();
+      const raw = jsonHandle.toString();
+      if (!raw) {
+        input.store.delete(key);
+        return vm.undefined;
+      }
+      try {
+        input.store.set(key, jsonClone(JSON.parse(raw)));
+      } catch {
+        input.store.delete(key);
+      }
+      return vm.undefined;
+    }).consume((handle) => vm.global.setProp('__ensoStore', handle));
+    vm.newFunction('__ensoLoad', (keyHandle: JSValueHandle) => {
+      const key = keyHandle.toString();
+      if (!input.store.has(key)) return vm.undefined;
+      const stored = input.store.get(key);
+      if (stored === undefined) {
+        input.store.delete(key);
+        return vm.undefined;
+      }
+      return vm.newString(JSON.stringify(stored));
+    }).consume((handle) => vm.global.setProp('__ensoLoad', handle));
+
+    const prelude = `
+      const __ensoWaiters = new Map();
+      globalThis.__ensoSettle = (id, ok, json) => {
+        const waiter = __ensoWaiters.get(id);
+        if (!waiter) return;
+        __ensoWaiters.delete(id);
+        if (ok) waiter.resolve(JSON.parse(json));
+        else waiter.reject(new Error(json));
+      };
+      function __ensoCall(name, args) {
+        const id = __ensoEnqueue(name, JSON.stringify(args === undefined ? {} : args));
+        return new Promise((resolve, reject) => {
+          __ensoWaiters.set(id, { resolve, reject });
+        });
+      }
+      for (const alias of ${JSON.stringify(aliases)}) {
+        globalThis[alias.callable] = (args) => __ensoCall(alias.tool, args);
+      }
+      globalThis.store = (key, value) => {
+        if (value === undefined) { __ensoStore(String(key), ''); return; }
+        __ensoStore(String(key), JSON.stringify(value));
+      };
+      globalThis.load = (key) => {
+        const raw = __ensoLoad(String(key));
+        return raw === undefined ? undefined : JSON.parse(raw);
+      };
+      globalThis.catalog = {
+        search(query, options) {
+          const q = String(query ?? "").toLowerCase();
+          const limit = options && options.limit > 0 ? options.limit : 20;
+          return ${JSON.stringify(names)}
+            .filter((name) => name.toLowerCase().includes(q))
+            .slice(0, limit)
+            .map((name) => globalThis[name]);
+        },
+        all() { return ${JSON.stringify(names)}.map((name) => globalThis[name]); },
+        list() { return ${JSON.stringify(listing)}; },
+      };
+      globalThis.listTools = () => ${JSON.stringify(listing)};
+      const __noConsole = () => { throw new Error('No console; use return for output'); };
+      globalThis.console = { log: __noConsole, info: __noConsole, warn: __noConsole, error: __noConsole, debug: __noConsole };
+    `;
+    vm.evalCode(prelude, 'enso-sandbox:prelude.js').dispose();
+
+    const resultHandle = vm.evalCode(`(async () => {\n${input.code}\n})()`, 'enso-sandbox.js');
+    const done = vm.resolvePromise(resultHandle);
+    let settled: Awaited<typeof done> | undefined;
+    const finish = done.then((value) => {
+      settled = value;
+      return value;
+    });
+
+    const settleJob = (id: string, ok: boolean, payload: unknown) => {
+      const settle = vm.global.getProp('__ensoSettle');
+      const idHandle = vm.newString(id);
+      const jsonHandle = vm.newString(JSON.stringify(payload));
+      try {
+        vm.callFunction(
+          settle,
+          vm.undefined,
+          idHandle,
+          ok ? vm.true : vm.false,
+          jsonHandle
+        ).dispose();
+      } finally {
+        settle.dispose();
+        idHandle.dispose();
+        jsonHandle.dispose();
+      }
+    };
+
+    const runJob = async (job: HostCall) => {
+      const tool = tools.get(job.name);
+      const args =
+        job.args && typeof job.args === 'object' && !Array.isArray(job.args) ? job.args : {};
+      const summary = callSummary(args);
+      let ok = true;
+      let payload: unknown = {};
+      let error: string | undefined;
+      pause();
+      try {
+        if (!tool) throw new Error(`Tool "${job.name}" is not available in the isolated sandbox`);
+        const nestedId = `${input.parentCallId}:${job.name}:${job.id}`;
+        const result = await tool.execute(
+          nestedId,
+          args as Record<string, unknown>,
+          input.signal,
+          undefined,
+          input.ctx as never
+        );
+        const isError = (result as { isError?: boolean }).isError === true;
+        ok = !isError;
+        payload = guestResult({ ...result, isError });
+        if (isError) error = textOf(result) || 'tool error';
+      } catch (caught) {
+        ok = false;
+        error = caught instanceof Error ? caught.message : String(caught);
+        payload = { content: error, isError: true };
+      } finally {
+        resume();
+      }
+      calls.push(
+        ok
+          ? { name: job.name, ok, ...(summary ? { summary } : {}) }
+          : { name: job.name, ok, error, ...(summary ? { summary } : {}) }
+      );
+      try {
+        settleJob(job.id, true, payload);
+        vm.executePendingJobs();
+      } catch {
+        /* vm already tearing down */
+      }
+    };
+
+    const drain = async () => {
+      const running = new Set<Promise<void>>();
+      const launch = () => {
+        if (settled) {
+          dropQueued(queue, calls);
+          return;
+        }
+        while (queue.length > 0 && running.size < MAX_INFLIGHT) {
+          const job = queue.shift();
+          if (!job) break;
+          let task!: Promise<void>;
+          task = runJob(job).finally(() => {
+            running.delete(task);
+          });
+          running.add(task);
+        }
+      };
+      launch();
+      while (running.size > 0) {
+        await Promise.race(running);
+        launch();
+      }
+    };
+
+    try {
+      while (!settled) {
+        if (input.signal?.aborted) return failed('isolated sandbox aborted', { calls });
+        if (elapsed() > TIMEOUT_MS) return failed('isolated sandbox timeout exceeded', { calls });
+        vm.executePendingJobs();
+        await Promise.resolve();
+        if (settled) {
+          dropQueued(queue, calls);
+          break;
+        }
+        if (queue.length > 0) await drain();
+        else await Promise.race([finish, new Promise((resolve) => setImmediate(resolve))]);
+      }
+
+      if ('error' in settled) {
+        const message =
+          settled.error instanceof JSException
+            ? `${settled.error.name}: ${settled.error.message}`
+            : String(vm.dump(settled.error));
+        settled.error.dispose();
+        return failed(withDidYouMean(message, names), { calls });
+      }
+      const value = jsonClone(vm.dump(settled.value));
+      settled.value.dispose();
+      const packed = packGuestOutput({ status: 'completed', value, calls });
+      return { content: [{ type: 'text' as const, text: packed.text }], details: packed.details };
+    } finally {
+      resultHandle.dispose();
+      void finish.catch(() => {});
+    }
+  } catch (error) {
+    const message =
+      error instanceof JSException
+        ? `${error.name}: ${error.message}`
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    return failed(message, { calls });
+  } finally {
+    vm.dispose();
+  }
+}

--- a/src/agent/readTruncation.test.ts
+++ b/src/agent/readTruncation.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeTruncationDetails, withReadTruncationMeta } from './readTruncation';
+
+describe('sanitizeTruncationDetails', () => {
+  it('去掉 truncation.content，补 shownLines/totalLines/nextOffset', () => {
+    const details = {
+      truncation: {
+        truncated: true,
+        content: 'x'.repeat(50_000),
+        outputLines: 1002,
+        totalLines: 15294,
+      },
+    };
+    expect(sanitizeTruncationDetails(details, 1)).toEqual({
+      truncation: {
+        truncated: true,
+        shownLines: 1002,
+        totalLines: 15294,
+        bytesLimit: 51200,
+        nextOffset: 1003,
+      },
+    });
+  });
+
+  it('从 offset 续读时 nextOffset 接在本页之后，totalLines 还原为文件总行数', () => {
+    const details = {
+      truncation: { truncated: true, content: 'body', outputLines: 10, totalLines: 40 },
+    };
+    expect(sanitizeTruncationDetails(details, 11)).toEqual({
+      truncation: {
+        truncated: true,
+        shownLines: 10,
+        totalLines: 50,
+        bytesLimit: 51200,
+        nextOffset: 21,
+      },
+    });
+  });
+
+  it('pi 的 totalLines 是剩余行，要加回 offset 才是 wc -l 总行数', () => {
+    expect(
+      sanitizeTruncationDetails(
+        {
+          truncation: {
+            truncated: true,
+            outputLines: 1002,
+            totalLines: 14291,
+          },
+        },
+        1003
+      )
+    ).toEqual({
+      truncation: {
+        truncated: true,
+        shownLines: 1002,
+        totalLines: 15293,
+        bytesLimit: 51200,
+        nextOffset: 2005,
+      },
+    });
+  });
+
+  it('无 truncation 或无 content 时不改形状以外的字段', () => {
+    expect(sanitizeTruncationDetails({ path: 'a.ts' })).toEqual({ path: 'a.ts' });
+  });
+});
+
+describe('withReadTruncationMeta', () => {
+  it('execute 后 details 不再带正文', async () => {
+    const inner = {
+      name: 'read',
+      async execute(_id: string, _params: unknown) {
+        return {
+          content: [{ type: 'text', text: 'shown' }],
+          details: {
+            truncation: {
+              truncated: true,
+              content: 'FULL',
+              outputLines: 2,
+              totalLines: 9,
+            },
+          },
+        };
+      },
+    };
+    const wrapped = withReadTruncationMeta(inner);
+    const result = await wrapped.execute('id', { path: 'a.ts' });
+    expect(result.details.truncation).toEqual({
+      truncated: true,
+      shownLines: 2,
+      totalLines: 9,
+      bytesLimit: 51200,
+      nextOffset: 3,
+    });
+    expect(JSON.stringify(result.details)).not.toContain('FULL');
+  });
+
+  it('页脚 of N 与 details.totalLines 都用 wc -l，不是剩余行或 split(\\n).length', async () => {
+    const inner = {
+      name: 'read',
+      async execute(_id: string, _params: unknown) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'shown\n\n[Showing lines 1003-2004 of 15294. Use offset=2005 to continue.]',
+            },
+          ],
+          details: {
+            truncation: {
+              truncated: true,
+              content: 'FULL',
+              outputLines: 1002,
+              totalLines: 14291,
+            },
+          },
+        };
+      },
+    };
+    const wrapped = withReadTruncationMeta(inner);
+    const result = await wrapped.execute('id', { path: 'a.ts', offset: 1003 });
+    expect(result.details.truncation).toMatchObject({ totalLines: 15293 });
+    expect(result.content[0].text).toContain('of 15293');
+    expect(result.content[0].text).not.toContain('of 15294');
+  });
+});

--- a/src/agent/readTruncation.ts
+++ b/src/agent/readTruncation.ts
@@ -1,0 +1,94 @@
+const DEFAULT_READ_BYTES_LIMIT = 50 * 1024;
+const SHOWING_LINES = /Showing lines \d+-\d+ of (\d+)/;
+
+function asPositiveInt(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function startLine(offset: number): number {
+  return Number.isFinite(offset) && offset > 1 ? Math.floor(offset) : 1;
+}
+
+/** pi 的 truncation.totalLines 是从 offset 起的剩余行（wc -l），还原成文件总行数。 */
+function fileTotalLines(remaining: number | undefined, offset: number): number | undefined {
+  if (remaining == null) return undefined;
+  const start = startLine(offset);
+  return start > 1 ? remaining + start - 1 : remaining;
+}
+
+function rewriteShowingFooter(text: string, totalLines: number): string {
+  return text.replace(SHOWING_LINES, (_all, reported: string) =>
+    Number(reported) === totalLines ? _all : _all.replace(` of ${reported}`, ` of ${totalLines}`)
+  );
+}
+
+/** 去掉 truncation.content 正文，只留分页续读需要的元数据。 */
+export function sanitizeTruncationDetails(details: unknown, offset = 1): unknown {
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return details;
+  const record = details as Record<string, unknown>;
+  const truncation = record.truncation;
+  if (!truncation || typeof truncation !== 'object' || Array.isArray(truncation)) return details;
+  const raw = truncation as Record<string, unknown>;
+  const shownLines = asPositiveInt(raw.outputLines);
+  const remainingLines = asPositiveInt(raw.totalLines);
+  const totalLines = fileTotalLines(remainingLines, offset);
+  const truncated =
+    raw.truncated === true ||
+    (shownLines != null && remainingLines != null && shownLines < remainingLines);
+  const start = startLine(offset);
+  const nextOffset = truncated && shownLines != null ? start + shownLines : undefined;
+  const bytesLimit =
+    asPositiveInt(raw.maxBytes) ?? (truncated ? DEFAULT_READ_BYTES_LIMIT : undefined);
+  const meta: Record<string, unknown> = {};
+  if (truncated) meta.truncated = true;
+  if (shownLines != null) meta.shownLines = shownLines;
+  if (totalLines != null) meta.totalLines = totalLines;
+  if (bytesLimit != null) meta.bytesLimit = bytesLimit;
+  if (nextOffset != null) meta.nextOffset = nextOffset;
+  return { ...record, truncation: meta };
+}
+
+export function withReadTruncationMeta<T extends { execute: (...args: never[]) => unknown }>(
+  definition: T
+): T {
+  const execute = definition.execute as (
+    toolCallId: string,
+    params: unknown,
+    ...rest: unknown[]
+  ) => unknown;
+  return {
+    ...definition,
+    execute: (async (toolCallId: string, params: unknown, ...rest: unknown[]) => {
+      const result = await execute(toolCallId, params, ...rest);
+      if (!result || typeof result !== 'object') return result;
+      const offset = Number((params as { offset?: unknown } | undefined)?.offset ?? 1);
+      const details = (result as { details?: unknown }).details;
+      const next = sanitizeTruncationDetails(details, offset);
+      const totalLines =
+        next && typeof next === 'object' && !Array.isArray(next)
+          ? asPositiveInt(
+              (next as { truncation?: { totalLines?: unknown } }).truncation?.totalLines
+            )
+          : undefined;
+      const content = (result as { content?: unknown }).content;
+      const rewritten =
+        typeof totalLines === 'number' && Array.isArray(content)
+          ? content.map((part) => {
+              if (!part || typeof part !== 'object') return part;
+              const item = part as { type?: string; text?: string };
+              if (item.type !== 'text' || typeof item.text !== 'string') return part;
+              const text = rewriteShowingFooter(item.text, totalLines);
+              return text === item.text ? part : { ...item, text };
+            })
+          : content;
+      if (next === details && rewritten === content) return result;
+      return {
+        ...(result as object),
+        ...(next === details ? {} : { details: next }),
+        ...(rewritten === content ? {} : { content: rewritten }),
+      };
+    }) as T['execute'],
+  };
+}

--- a/src/agent/supervisor.coworkerWait.test.ts
+++ b/src/agent/supervisor.coworkerWait.test.ts
@@ -630,4 +630,92 @@ describe('SessionSupervisor coworker wait/report', () => {
     await settle();
     expect(mocks.loaderOptions[2]?.noExtensions).not.toBe(true);
   });
+
+  it('子会话跟父开关下发 exec + explore-fold，不含嵌套 hire', async () => {
+    const events: AgentWorkerEvent[] = [];
+    const supervisor = new SessionSupervisor({
+      emit: (event) => events.push(event),
+      agentDir: '/tmp/agent',
+      sessionDir: mkdtempSync(path.join(tmpdir(), 'enso-cw-')),
+    });
+    supervisor.handleCommand({
+      type: 'spawn-parent',
+      identity: parent,
+      cwd: '/workspace',
+      model,
+      exploreFoldEnabled: true,
+    });
+    await settleUntil(() => mocks.createAgentSession.mock.calls.length > 0);
+    const parentTools = (
+      mocks.createAgentSession.mock.calls[0][0] as { customTools: Array<{ name: string }> }
+    ).customTools.map((tool) => tool.name);
+    expect(parentTools).toEqual(expect.arrayContaining(['exec', 'explore_mark', 'explore_fold']));
+    const coworkerTool = (
+      mocks.createAgentSession.mock.calls[0][0] as { customTools: CoworkerToolLike[] }
+    ).customTools.find(
+      (tool) => (tool as unknown as { name: string }).name === 'coworker'
+    ) as unknown as CoworkerToolLike;
+    await coworkerTool.execute(
+      't1',
+      { operation: 'spawn', name: 'bob', task: 'first task' },
+      undefined,
+      undefined,
+      {} as never
+    );
+    await settle();
+    const childTools = (
+      mocks.createAgentSession.mock.calls[1][0] as { customTools: Array<{ name: string }> }
+    ).customTools.map((tool) => tool.name);
+    expect(childTools).toEqual(expect.arrayContaining(['exec', 'explore_mark', 'explore_fold']));
+    expect(childTools).not.toContain('coworker');
+    expect(childTools).not.toContain('subagent');
+    const childFactories = mocks.loaderOptions[1]?.extensionFactories as
+      | Array<{ name?: string }>
+      | undefined;
+    expect(childFactories?.some((factory) => factory.name === 'explore-fold')).toBe(true);
+  });
+
+  it('父关掉 isolated_sandbox / explore-fold 时子也不下发', async () => {
+    const events: AgentWorkerEvent[] = [];
+    const supervisor = new SessionSupervisor({
+      emit: (event) => events.push(event),
+      agentDir: '/tmp/agent',
+      sessionDir: mkdtempSync(path.join(tmpdir(), 'enso-cw-')),
+    });
+    supervisor.handleCommand({
+      type: 'spawn-parent',
+      identity: parent,
+      cwd: '/workspace',
+      model,
+      disabledTools: ['isolated_sandbox'],
+    });
+    await settleUntil(() => mocks.createAgentSession.mock.calls.length > 0);
+    const parentTools = (
+      mocks.createAgentSession.mock.calls[0][0] as { customTools: Array<{ name: string }> }
+    ).customTools.map((tool) => tool.name);
+    expect(parentTools).not.toContain('exec');
+    expect(parentTools).not.toContain('explore_mark');
+    const coworkerTool = (
+      mocks.createAgentSession.mock.calls[0][0] as { customTools: CoworkerToolLike[] }
+    ).customTools.find(
+      (tool) => (tool as unknown as { name: string }).name === 'coworker'
+    ) as unknown as CoworkerToolLike;
+    await coworkerTool.execute(
+      't1',
+      { operation: 'spawn', name: 'bob', task: 'first task' },
+      undefined,
+      undefined,
+      {} as never
+    );
+    await settle();
+    const childTools = (
+      mocks.createAgentSession.mock.calls[1][0] as { customTools: Array<{ name: string }> }
+    ).customTools.map((tool) => tool.name);
+    expect(childTools).not.toContain('exec');
+    expect(childTools).not.toContain('explore_mark');
+    const childFactories = mocks.loaderOptions[1]?.extensionFactories as
+      | Array<{ name?: string }>
+      | undefined;
+    expect(childFactories?.some((factory) => factory.name === 'explore-fold')).toBeFalsy();
+  });
 });

--- a/src/agent/supervisor.ts
+++ b/src/agent/supervisor.ts
@@ -108,12 +108,14 @@ import { InMemorySnapshotStore } from './hashline/snapshots';
 import { wrapHashlineEditDefinition } from './hashline/tools';
 import { withHashlineWrite } from './hashline/withWrite';
 import { type ContextMessage, pruneHistoricalImages } from './imageContext';
+import { createIsolatedSandboxTool } from './isolatedSandbox';
 import { McpManager } from './mcp';
 import { createMessageCoworkerTool } from './messageCoworker';
 import { createMessageMainTool } from './messageMain';
 import { ParentNotifier } from './notify';
 import { projectMessage } from './projection';
 import { applyWorkerProxyEnv } from './proxyEnv';
+import { withReadTruncationMeta } from './readTruncation';
 import { projectMessages, projectResumeTail } from './resumeSnapshots';
 import {
   EVICTION_SWEEP_INTERVAL_MS,
@@ -318,31 +320,27 @@ function createSessionResourceLoader(options: {
           }));
         },
       } satisfies InlineExtension,
-      ...(!options.noExtensions && (options.exploreFold || options.smartCompactEnabled)
+      ...(options.exploreFold
         ? [
-            ...(options.exploreFold
-              ? [
-                  {
-                    name: 'explore-fold',
-                    hidden: true,
-                    factory: (pi) => {
-                      pi.on('context', (event) => ({
-                        messages: options.exploreFold!.apply(
-                          event.messages as never
-                        ) as typeof event.messages,
-                      }));
-                    },
-                  } satisfies InlineExtension,
-                ]
-              : []),
-            ...(options.smartCompactEnabled
-              ? [
-                  smartCompactInlineExtension({
-                    summaryModel: options.smartCompactSummaryModel,
-                    mode: options.smartCompactMode,
-                  }),
-                ]
-              : []),
+            {
+              name: 'explore-fold',
+              hidden: true,
+              factory: (pi) => {
+                pi.on('context', (event) => ({
+                  messages: options.exploreFold!.apply(
+                    event.messages as never
+                  ) as typeof event.messages,
+                }));
+              },
+            } satisfies InlineExtension,
+          ]
+        : []),
+      ...(!options.noExtensions && options.smartCompactEnabled
+        ? [
+            smartCompactInlineExtension({
+              summaryModel: options.smartCompactSummaryModel,
+              mode: options.smartCompactMode,
+            }),
           ]
         : []),
     ],
@@ -1276,7 +1274,8 @@ export class SessionSupervisor {
         ? { readFile: remoteOps.read.readFile, writeFile: remoteOps.edit.writeFile }
         : undefined,
     });
-    const wrapRead = (definition: Def): Def => withAgentRead(definition, () => structuredById);
+    const wrapRead = (definition: Def): Def =>
+      withReadTruncationMeta(withAgentRead(definition, () => structuredById));
     const applyHashline = <T extends Def>(tools: { read: T; grep: T; edit?: T }) =>
       applyHashlineSessionTools({
         enabled: hashlineEditEnabled,
@@ -1480,7 +1479,10 @@ export class SessionSupervisor {
                 }
               )
             : undefined;
-        const subTools = isLockedEnso
+        const childExploreFold =
+          !isLockedEnso && exploreFoldEnabled ? createExploreFoldState() : undefined;
+        const childSandboxCatalog: { current: Def[] } = { current: [] };
+        const childTools = isLockedEnso
           ? [createEnsoCapabilitiesTool(), createEnsoAppTool(ensoApp!), createAskTool(askManager!)]
           : [
               ...(resolved?.tools === 'readonly' || agentType?.tools === 'readonly'
@@ -1488,6 +1490,21 @@ export class SessionSupervisor {
                 : buildBaseTools(childGate, undefined, agentType?.writeScope)),
               ...(resolved || agentType ? typeMcpTools : wrapMcpTools(childGate)),
               ...(extraTools as Def[]),
+              ...(childExploreFold ? createExploreFoldTools(childExploreFold) : []),
+            ];
+        childSandboxCatalog.current = childTools;
+        const subTools = isLockedEnso
+          ? childTools
+          : [
+              ...childTools,
+              ...(toolEnabled('isolated_sandbox')
+                ? [
+                    createIsolatedSandboxTool({
+                      getTools: () => childSandboxCatalog.current,
+                      store: new Map(),
+                    }),
+                  ]
+                : []),
             ];
         const selectedSkillPaths = resolved?.skillPaths ?? agentType?.skillPaths ?? [];
         const subLoader = isLockedEnso
@@ -1502,6 +1519,7 @@ export class SessionSupervisor {
               remoteAgentsFiles,
               // 类型化子代理与项目资源隔离（同 noSkills/noExtensions），不追加 harness 资源
               loadHarnessAssets: resolved || agentType ? false : loadHarnessAssets,
+              ...(childExploreFold ? { exploreFold: childExploreFold } : {}),
             });
         await subLoader.reload();
         const safeJournal =
@@ -1549,7 +1567,8 @@ export class SessionSupervisor {
         };
       },
     };
-    // 子代理：同 worker 子会话，复用 runtime/model/审批门/MCP 连接；工具同父但不含 task/todo（防递归）
+    // 子代理：同 worker 子会话，复用 runtime/model/审批门/MCP 连接；不含 subagent/coworker（防递归）。
+    // 隔离沙箱 / 探后折叠跟父会话同一开关，catalog 用子自己的工具集。
     const taskTool = createSubagentTool({
       modelId: model.modelId,
       agentTypes,
@@ -1659,7 +1678,9 @@ export class SessionSupervisor {
           });
         })
       : undefined;
-    const customTools = [
+    const catalogRef: { current: Def[] } = { current: [] };
+    const sandboxStore = new Map<string, unknown>();
+    const sessionTools = [
       ...buildCoreTools(),
       ...(browser
         ? createBrowserTools(browser).map((tool) => withNavigateApproval(gate, tool))
@@ -1682,6 +1703,13 @@ export class SessionSupervisor {
               note,
             });
           })
+        : []),
+    ];
+    catalogRef.current = sessionTools;
+    const customTools = [
+      ...sessionTools,
+      ...(toolEnabled('isolated_sandbox')
+        ? [createIsolatedSandboxTool({ getTools: () => catalogRef.current, store: sandboxStore })]
         : []),
     ].map((tool) => withTaskReminders(tool, takePendingReminders));
 

--- a/src/main/services/agentHost.ts
+++ b/src/main/services/agentHost.ts
@@ -21,6 +21,7 @@ import { mcpTimeoutsForSpawn } from '@shared/mcpTimeout';
 import { pickModelCapabilityOverrides } from '@shared/modelCatalog';
 import { proxyEnvPatchFromEnv } from '@shared/proxy';
 import { parseSmartCompactMode } from '@shared/smartCompactMode';
+import { effectiveDisabledBuiltinTools } from '@shared/types';
 import type {
   AgentCommand,
   AgentRemoteConfig,
@@ -393,9 +394,7 @@ export function spawnSession(
   const subagentModels = configuredSubagentModels(authenticatedAccountKeys);
   const agentTypes = configuredAgentTypes(authenticatedAccountKeys, subagentModels.length > 0);
   const state = readSettingsState();
-  const disabledTools = Array.isArray(state?.disabledBuiltinTools)
-    ? state.disabledBuiltinTools.filter((id): id is string => typeof id === 'string')
-    : [];
+  const disabledTools = effectiveDisabledBuiltinTools(state?.disabledBuiltinTools);
   const loadHarnessAssets = state?.loadHarnessAssets === true;
   const windowsLocalShell = parseWindowsLocalShell(state?.windowsLocalShell);
   const exploreFoldEnabled = state?.exploreFoldEnabled === true;

--- a/src/main/services/capabilityGateway.ts
+++ b/src/main/services/capabilityGateway.ts
@@ -29,6 +29,7 @@ import {
   type AgentTypeEntry,
   BUILTIN_AGENT_TYPES,
   BUILTIN_TOOLS,
+  effectiveDisabledBuiltinTools,
   MODEL_THINKING_LEVEL_OVERRIDES,
   type ModelProvider,
   type Preset,
@@ -1227,9 +1228,8 @@ export function createCapabilityHandlers(
       );
     },
     'tools.list': () => {
-      const current = settingsState(services.readSettings()).disabledBuiltinTools;
       const disabled = new Set(
-        Array.isArray(current) ? current.filter((id): id is string => typeof id === 'string') : []
+        effectiveDisabledBuiltinTools(settingsState(services.readSettings()).disabledBuiltinTools)
       );
       return success(BUILTIN_TOOLS.map((tool) => ({ ...tool, enabled: !disabled.has(tool.id) })));
     },
@@ -1238,11 +1238,8 @@ export function createCapabilityHandlers(
       if (!id || typeof params.enabled !== 'boolean') return invalid('id and enabled are required');
       if (!BUILTIN_TOOLS.some((tool) => tool.id === id))
         return invalid(`Unknown built-in tool: ${id}`);
-      const current = settingsState(services.readSettings()).disabledBuiltinTools;
       const disabled = new Set(
-        Array.isArray(current)
-          ? current.filter((value): value is string => typeof value === 'string')
-          : []
+        effectiveDisabledBuiltinTools(settingsState(services.readSettings()).disabledBuiltinTools)
       );
       if (params.enabled) disabled.delete(id);
       else disabled.add(id);

--- a/src/renderer/components/chat/ApprovalBar.tsx
+++ b/src/renderer/components/chat/ApprovalBar.tsx
@@ -71,7 +71,11 @@ export function ApprovalBar({ approvals, onRespond, allowSession = true }: Appro
         </span>
         <span className="flex min-w-0 items-center gap-1 text-muted-foreground">
           <Icon className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate font-mono">{active.tool}</span>
+          <span className="truncate font-mono">
+            {(active.toolCallId?.split(':').length ?? 0) >= 3
+              ? `${t('Isolated sandbox')} › ${active.tool}`
+              : active.tool}
+          </span>
         </span>
         {approvals.length > 1 && (
           <span className="ml-auto shrink-0 text-[10px] text-muted-foreground tabular-nums">

--- a/src/renderer/components/chat/TimelineRow.tsx
+++ b/src/renderer/components/chat/TimelineRow.tsx
@@ -37,8 +37,9 @@ import { addSidePanelChanges } from '@/lib/sidePanelDock';
 import { cn } from '@/lib/utils';
 import { useSessionsStore } from '@/stores/sessions';
 import { formatDuration, formatTokens } from '@/stores/sessions/stats';
-import { isReadOnlyTool, type TimelineItem } from '@/stores/sessions/timeline';
+import { isReadOnlyTool, parseSandboxOutput, type TimelineItem } from '@/stores/sessions/timeline';
 import { useSettingsStore } from '@/stores/settings';
+import { CodeBlock } from './CodeBlock';
 import { ConfirmDialog } from './ConfirmDialog';
 import { useChatHost } from './chatHost';
 import { EditDiff } from './EditDiff';
@@ -104,7 +105,9 @@ function itemEqual(prev: TimelineRowProps, next: TimelineRowProps): boolean {
         a.todos === b.todos &&
         a.durationMs === b.durationMs &&
         a.startedAt === b.startedAt &&
-        a.agentMeta === b.agentMeta
+        a.agentMeta === b.agentMeta &&
+        a.source === b.source &&
+        a.nestedPending === b.nestedPending
       );
     case 'tool-group':
       return (
@@ -1190,6 +1193,66 @@ function ToolContentScroller({
   );
 }
 
+function formatSandboxValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2) ?? '';
+  } catch {
+    return String(value);
+  }
+}
+
+function SandboxOutput({
+  source,
+  output,
+  view,
+}: {
+  source?: string | null;
+  output: string | null;
+  view: ReturnType<typeof parseSandboxOutput>;
+}) {
+  const value =
+    view?.status === 'completed' ? formatSandboxValue(view.value) : (view?.error ?? output);
+  return (
+    <div className="space-y-1 px-3 py-1">
+      {source ? <CodeBlock code={source} language="javascript" /> : null}
+      {view && view.calls.length > 0 ? (
+        <div className="flex flex-wrap gap-1">
+          {[...new Map(view.calls.map((call) => [call.name, call])).keys()].map((name) => {
+            const group = view.calls.filter((call) => call.name === name);
+            const failed = group.find((call) => !call.ok);
+            const label = `${name} ×${group.length}`;
+            return (
+              <span
+                key={name}
+                className={cn(
+                  'rounded-md border px-1.5 py-0.5 font-mono text-[10px]',
+                  failed ? 'border-destructive/40 text-destructive' : 'text-muted-foreground'
+                )}
+                title={group
+                  .map((call) => call.summary)
+                  .filter(Boolean)
+                  .join('\n')}
+              >
+                {failed ? `${label} · ${failed.error ?? 'error'}` : label}
+              </span>
+            );
+          })}
+        </div>
+      ) : null}
+      {value ? (
+        view?.status === 'completed' && typeof view.value !== 'string' ? (
+          <CodeBlock code={value} language="json" />
+        ) : (
+          <pre className="font-mono text-xs leading-relaxed text-muted-foreground whitespace-pre-wrap">
+            {value}
+          </pre>
+        )
+      ) : null}
+    </div>
+  );
+}
+
 /** 单行工具摘要：状态点/图标 + 工具名 + 参数摘要；edit 展开为 diff,write 展开为写入内容,其余为输出 */
 function ToolRow({ item }: { item: Extract<TimelineItem, { kind: 'tool' }> }) {
   const { t } = useI18n();
@@ -1198,7 +1261,14 @@ function ToolRow({ item }: { item: Extract<TimelineItem, { kind: 'tool' }> }) {
   const compact = compactReadOnly && isReadOnlyTool(item);
   const hasDiff = Boolean(item.edits && item.edits.length > 0);
   const hasWrite = Boolean(item.writeContent);
-  const expandable = hasDiff || hasWrite || Boolean(item.output);
+  const sandbox = item.name === 'exec' ? parseSandboxOutput(item.output) : null;
+  const headerSummary =
+    item.nestedPending && item.state === 'running'
+      ? `${item.summary} · ${item.nestedPending} pending`
+      : sandbox?.calls.length && item.state !== 'error'
+        ? `${item.summary} · ${sandbox.calls.length} calls`
+        : item.summary;
+  const expandable = hasDiff || hasWrite || Boolean(item.output) || Boolean(item.source);
   // edit 的 diff 与 write 的内容只在本轮直播（running）且开启 expandLiveEdits 时默认展开；
   // 历史会话挂载时全部折叠——否则切会话时视口内成排 FileDiff 同步解析+高亮，
   // 主线程阻塞几秒白屏
@@ -1230,7 +1300,9 @@ function ToolRow({ item }: { item: Extract<TimelineItem, { kind: 'tool' }> }) {
           )}
         >
           {(!compact || item.state !== 'ok') && <ToolStateIcon state={item.state} />}
-          <span className={cn('shrink-0', !compact && 'font-medium')}>{item.name}</span>
+          <span className={cn('shrink-0', !compact && 'font-medium')}>
+            {item.name === 'exec' ? t('Isolated sandbox') : item.name}
+          </span>
           {item.summary && (
             <>
               {!compact && <span className="text-muted-foreground/50">·</span>}
@@ -1241,7 +1313,7 @@ function ToolRow({ item }: { item: Extract<TimelineItem, { kind: 'tool' }> }) {
                   item.state === 'error' ? 'text-destructive' : 'text-muted-foreground'
                 )}
               >
-                {item.state === 'error' && item.output ? firstLine(item.output) : item.summary}
+                {item.state === 'error' && item.output ? firstLine(item.output) : headerSummary}
               </span>
             </>
           )}
@@ -1297,7 +1369,7 @@ function ToolRow({ item }: { item: Extract<TimelineItem, { kind: 'tool' }> }) {
           <ReadFileView path={item.summary} contents={item.writeContent} />
         </ToolContentScroller>
       )}
-      {expanded && !hasDiff && !hasWrite && item.output && (
+      {expanded && !hasDiff && !hasWrite && (item.output || item.source) && (
         <ToolContentScroller
           follow={item.state === 'running'}
           className={
@@ -1306,13 +1378,15 @@ function ToolRow({ item }: { item: Extract<TimelineItem, { kind: 'tool' }> }) {
               : 'rounded-b-lg border-t border-border/60'
           }
         >
-          {item.name === 'bash' ? (
-            <TerminalOutput command={item.summary} output={item.output} />
+          {item.name === 'exec' ? (
+            <SandboxOutput source={item.source} output={item.output} view={sandbox} />
+          ) : item.name === 'bash' ? (
+            <TerminalOutput command={item.summary} output={item.output ?? ''} />
           ) : item.name === 'read' ? (
-            <ReadFileView path={item.summary} contents={item.output} />
+            <ReadFileView path={item.summary} contents={item.output ?? ''} />
           ) : item.name === 'subagent' && item.state !== 'error' ? (
             <div className="px-3 py-2 text-sm">
-              <Markdown text={item.output} />
+              <Markdown text={item.output ?? ''} />
             </div>
           ) : (
             <pre className="px-3 py-2 font-mono text-xs leading-relaxed text-muted-foreground whitespace-pre-wrap">

--- a/src/renderer/components/settings/BuiltinToolsSettings.tsx
+++ b/src/renderer/components/settings/BuiltinToolsSettings.tsx
@@ -46,7 +46,7 @@ export function BuiltinToolsSettings() {
           <OccupancyEnabledTotal tokens={enabledTokens} />
         </h3>
         <p className="text-muted-foreground text-sm">
-          {t('Toggle the built-in tools available to agents. All enabled by default.')}
+          {t('Toggle the built-in tools available to agents.')}
         </p>
       </div>
 
@@ -55,7 +55,7 @@ export function BuiltinToolsSettings() {
           <div key={tool.id} className="flex items-center gap-3 rounded-md border px-3 py-2.5">
             <Wrench className="h-4 w-4 shrink-0 text-muted-foreground" />
             <div className="min-w-0 flex-1">
-              <p className="text-sm font-medium">{tool.name}</p>
+              <p className="text-sm font-medium">{t(tool.name)}</p>
               <p className="text-muted-foreground text-xs">{t(tool.description)}</p>
             </div>
             <OccupancyMark

--- a/src/renderer/stores/sessions/timeline.test.ts
+++ b/src/renderer/stores/sessions/timeline.test.ts
@@ -5,6 +5,7 @@ import {
   foldTimeline,
   historyPageChrome,
   isReadOnlyCommand,
+  parseSandboxOutput,
   type TimelineItem,
   terminalErrorText,
 } from './timeline';
@@ -64,6 +65,51 @@ describe('buildTimeline', () => {
       summary: 'a.ts',
       output: 'file body',
       state: 'ok',
+    });
+  });
+
+  it('exec 摘要用首行 JS，source 保留全文，结果 JSON 解析为 value/calls', () => {
+    const code = 'const pkg = await read({ path: "package.json" });\nreturn pkg;';
+    const output = JSON.stringify({
+      status: 'completed',
+      value: { ok: true },
+      calls: [
+        { name: 'read', ok: true },
+        { name: 'ls', ok: true },
+      ],
+    });
+    const timeline = buildTimeline(
+      [
+        user('试试 code mode'),
+        {
+          role: 'assistant',
+          content: [{ type: 'toolCall', id: 'e1', name: 'exec', arguments: { code } }],
+        },
+        {
+          role: 'toolResult',
+          toolCallId: 'e1',
+          toolName: 'exec',
+          isError: false,
+          content: [{ type: 'text', text: output }],
+        },
+      ],
+      false
+    );
+    expect(timeline[1]).toMatchObject({
+      kind: 'tool',
+      name: 'exec',
+      summary: 'const pkg = await read({ path: "package.json" });',
+      source: code,
+      output,
+      state: 'ok',
+    });
+    expect(parseSandboxOutput(output)).toEqual({
+      status: 'completed',
+      value: { ok: true },
+      calls: [
+        { name: 'read', ok: true },
+        { name: 'ls', ok: true },
+      ],
     });
   });
 

--- a/src/renderer/stores/sessions/timeline.ts
+++ b/src/renderer/stores/sessions/timeline.ts
@@ -53,6 +53,10 @@ export type TimelineItem =
       startedAt?: number | null;
       /** subagent 工具的执行元数据（模型/token/步数）；非 subagent 为 null */
       agentMeta: { modelId?: string; outputTokens?: number; steps?: number } | null;
+      /** exec / 隔离沙箱的 JS 源码；其它工具缺省 */
+      source?: string | null;
+      /** 嵌套审批未决数（exec 脚本内 write 等） */
+      nestedPending?: number;
     }
   | {
       kind: 'tool-group';
@@ -165,6 +169,73 @@ export function historyPageChrome(
   if (loading) return 'loading';
   if (hasOlder === false && everHadOlder) return 'start';
   return 'none';
+}
+
+export function execSourceFromArgs(args: unknown): string | null {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return null;
+  const record = args as Record<string, unknown>;
+  const code = [record.code, record.command].find(
+    (value) => typeof value === 'string' && value.trim()
+  );
+  return typeof code === 'string' ? code : null;
+}
+
+export function summarizeExecSource(code: string): string {
+  const line =
+    code
+      .split('\n')
+      .map((part) => part.trim())
+      .find(Boolean) ?? '';
+  return line.length > 72 ? `${line.slice(0, 72)}…` : line;
+}
+
+export interface SandboxCallView {
+  name: string;
+  ok: boolean;
+  error?: string;
+  summary?: string;
+}
+
+export interface SandboxView {
+  status: 'completed' | 'failed';
+  value?: unknown;
+  error?: string;
+  calls: SandboxCallView[];
+}
+
+export function parseSandboxOutput(output: string | null): SandboxView | null {
+  if (!output?.trim()) return null;
+  try {
+    const parsed: unknown = JSON.parse(output);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const record = parsed as Record<string, unknown>;
+    if (record.status !== 'completed' && record.status !== 'failed') return null;
+    const calls = Array.isArray(record.calls)
+      ? record.calls.flatMap((entry) => {
+          if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+          const call = entry as Record<string, unknown>;
+          if (typeof call.name !== 'string' || !call.name) return [];
+          return [
+            {
+              name: call.name,
+              ok: call.ok === true,
+              ...(typeof call.error === 'string' ? { error: call.error } : {}),
+              ...(typeof call.summary === 'string' ? { summary: call.summary } : {}),
+            },
+          ];
+        })
+      : [];
+    return {
+      status: record.status,
+      ...(record.status === 'failed' && typeof record.error === 'string'
+        ? { error: record.error }
+        : {}),
+      ...(record.status === 'completed' ? { value: record.value } : {}),
+      calls,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /** write 工具参数里取出写入内容 */
@@ -307,9 +378,22 @@ function reviewingToolCallIds(
 ): Set<string> {
   const ids = new Set<string>();
   for (const request of pendingApprovals ?? []) {
-    if (request.phase === 'reviewing' && request.toolCallId) ids.add(request.toolCallId);
+    if (request.phase === 'reviewing' && request.toolCallId) {
+      ids.add(request.toolCallId);
+      const parent = request.toolCallId.split(':')[0];
+      if (parent) ids.add(parent);
+    }
   }
   return ids;
+}
+
+function nestedPendingCount(
+  toolCallId: string,
+  pendingApprovals: readonly ApprovalRequestInfo[] | undefined
+): number {
+  const prefix = `${toolCallId}:`;
+  return (pendingApprovals ?? []).filter((request) => request.toolCallId?.startsWith(prefix))
+    .length;
 }
 
 function buildMessageTimeline(
@@ -486,14 +570,21 @@ function buildMessageTimeline(
           const result = results.get(part.id);
           // 未完成时退而用执行中的输出快照（空串不算，否则行会变“可展开但空”）
           const partial = toolOutputs?.[part.id];
+          const execSource = part.name === 'exec' ? execSourceFromArgs(part.arguments) : null;
+          const output = result ? result.output : (partial ?? null) || null;
+          const sandboxView = part.name === 'exec' ? parseSandboxOutput(output) : null;
           items.push({
             kind: 'tool',
             key,
             name: part.name,
-            summary: summarizeArgs(part.arguments, cwd),
-            output: result ? result.output : (partial ?? null) || null,
+            summary: execSource
+              ? summarizeExecSource(execSource)
+              : summarizeArgs(part.arguments, cwd),
+            source: execSource,
+            output,
+            nestedPending: nestedPendingCount(part.id, pendingApprovals) || undefined,
             state: result
-              ? result.isError
+              ? result.isError || sandboxView?.status === 'failed'
                 ? 'error'
                 : 'ok'
               : running && messageIndex === lastTurnIndex

--- a/src/renderer/stores/settings/index.ts
+++ b/src/renderer/stores/settings/index.ts
@@ -12,6 +12,7 @@ import {
   type StatusLineSegmentId,
 } from '@shared/statusLine';
 import { parseTerminalShell } from '@shared/terminalShell';
+import { DEFAULT_DISABLED_BUILTIN_TOOLS } from '@shared/types';
 import type { SourceAuthorityProjection } from '@shared/types/agent';
 import { parseUsageModelPricing } from '@shared/usage/pricing';
 import { parseWindowsLocalShell } from '@shared/windowsLocalShell';
@@ -170,7 +171,7 @@ const initialState = {
   subagentModelsEnabled: false,
   subagentModels: [] as import('@shared/types').SubagentModelEntry[],
   disabledBuiltinAgentTypes: [] as string[],
-  disabledBuiltinTools: [] as string[],
+  disabledBuiltinTools: [...DEFAULT_DISABLED_BUILTIN_TOOLS] as string[],
   onboarded: false,
   keybindings: {} as Record<string, string>,
   projects: [] as import('@shared/types').Project[],

--- a/src/shared/capabilities/catalog.ts
+++ b/src/shared/capabilities/catalog.ts
@@ -1214,6 +1214,13 @@ export const CAPABILITY_CATALOG = {
     reason: 'Enso never receives browsing or page-interaction tools.',
     suggestedAction: 'Ask the coding agent to use the built-in browser.',
   }),
+  'coding-tools.isolated-sandbox': unavailable('coding-tools.isolated-sandbox', {
+    description: 'Run JavaScript that calls coding-session tools, including edits.',
+    risk: 'dangerous',
+    targetContext: 'origin-project',
+    reason: 'Enso never receives the coding-session isolated sandbox.',
+    suggestedAction: 'Ask the coding agent to use the isolated sandbox.',
+  }),
 } as const satisfies Record<ProductSurfaceId, CapabilitySpec<ProductSurfaceId, ProductSurfaceId>>;
 
 export type CapabilityCatalog = typeof CAPABILITY_CATALOG;

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -518,6 +518,8 @@ export const zhTranslations: Record<string, string> = {
   'Use the unrestricted coworker tool.': '使用不受限的 Coworker 工具。',
   'Run a background shell task.': '运行后台 shell 任务。',
   "Browse pages in Enso's built-in browser.": '在 Enso 内嵌浏览器里浏览页面。',
+  'Run JavaScript that calls coding-session tools, including edits.':
+    '运行会调用编码会话工具（含编辑）的 JavaScript。',
   Save: '保存',
   // Skills & MCP
   Skills: '技能',
@@ -780,8 +782,10 @@ export const zhTranslations: Record<string, string> = {
   Remove: '移除',
   'Agent types': '子代理类型',
   'Built-in tools': '内置工具',
-  'Toggle the built-in tools available to agents. All enabled by default.':
-    '开关 agent 可用的内置工具,默认全部启用。',
+  'Toggle the built-in tools available to agents.': '开关 agent 可用的内置工具。',
+  'Isolated sandbox': '隔离沙箱',
+  'Run JavaScript in an isolated sandbox that can call session tools. Intermediate reads and edits stay out of the chat; only the returned value is added to the conversation.':
+    '在隔离沙箱里跑 JavaScript，并可调用会话工具。中间的读取和修改不会进对话，只有返回值会留下。',
   'One-shot subagent: delegate a self-contained task and return a final report (parallel or async)':
     '一次性子代理:委派自包含子任务,返回最终报告(可并行、可异步)',
   'Persistent subagent: hire for multi-turn dialogue; you can watch and intervene from a tab':
@@ -793,6 +797,8 @@ export const zhTranslations: Record<string, string> = {
     '后台 shell 任务:长命令挂后台跑,完成时通知',
   "Built-in browser: open pages in Enso's own Chromium, read snapshots, click and type by ref":
     '内嵌浏览器:在 Enso 自带 Chromium 里打开页面,读快照,按 ref 点击与输入',
+  'QuickJS sandbox: write JavaScript that calls session tools (including edits) in one cell':
+    'QuickJS 沙箱:用 JavaScript 在一个 cell 里调用会话工具(含编辑)',
   '(log unavailable)': '(日志不可用)',
   'Loading…': '加载中…',
   '(no log available)': '(暂无日志)',

--- a/src/shared/productSurfaces.ts
+++ b/src/shared/productSurfaces.ts
@@ -482,6 +482,11 @@ export const PRODUCT_SURFACE_INVENTORY = {
     kind: 'action',
     label: 'Use built-in browser',
   },
+  'coding-tools.isolated-sandbox': {
+    domain: 'coding-tools',
+    kind: 'action',
+    label: 'Run isolated sandbox',
+  },
 } as const satisfies Record<string, ProductSurfaceInventoryItem>;
 
 export type ProductSurfaceId = keyof typeof PRODUCT_SURFACE_INVENTORY;

--- a/src/shared/types/builtinTools.test.ts
+++ b/src/shared/types/builtinTools.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { effectiveDisabledBuiltinTools } from './builtinTools';
+
+describe('effectiveDisabledBuiltinTools', () => {
+  it('缺字段时用默认关闭列表（空 = 全开）', () => {
+    expect(effectiveDisabledBuiltinTools(undefined)).toEqual([]);
+  });
+
+  it('只保留字符串 id，列表原样透传', () => {
+    expect(effectiveDisabledBuiltinTools(['browser', 1, 'isolated_sandbox'])).toEqual([
+      'browser',
+      'isolated_sandbox',
+    ]);
+  });
+});

--- a/src/shared/types/builtinTools.ts
+++ b/src/shared/types/builtinTools.ts
@@ -1,4 +1,4 @@
-/** 内置工具:设置页可开关,默认全开;禁用后不下发给会话(模型看不到) */
+/** 内置工具:设置页可开关;禁用后不下发给会话(模型看不到)。默认全开,见 DEFAULT_DISABLED_BUILTIN_TOOLS。 */
 export interface BuiltinToolInfo {
   /** 稳定 id,用于开关持久化与下发过滤 */
   id: string;
@@ -38,4 +38,20 @@ export const BUILTIN_TOOLS: BuiltinToolInfo[] = [
     description:
       'Background shell task: run long commands in the background and notify on completion',
   },
+  {
+    id: 'isolated_sandbox',
+    name: 'Isolated sandbox',
+    description:
+      'Run JavaScript in an isolated sandbox that can call session tools. Intermediate reads and edits stay out of the chat; only the returned value is added to the conversation.',
+  },
 ];
+
+/** 新会话/新安装默认关闭的内置工具。用户打开后从 disabledBuiltinTools 里去掉。 */
+export const DEFAULT_DISABLED_BUILTIN_TOOLS = [] as const;
+
+/** Main 直读磁盘时把未知形状收成 string[]；缺字段走默认关闭列表（空 = 全开）。 */
+export function effectiveDisabledBuiltinTools(disabled: unknown): string[] {
+  return Array.isArray(disabled)
+    ? disabled.filter((id): id is string => typeof id === 'string')
+    : [...DEFAULT_DISABLED_BUILTIN_TOOLS];
+}

--- a/src/tooling/productCapabilityCoverage.fixture.ts
+++ b/src/tooling/productCapabilityCoverage.fixture.ts
@@ -252,6 +252,7 @@ export const BUILTIN_TOOL_COVERAGE: Readonly<Record<string, CoverageDisposition>
   ask_user: surfaces('coding-tools.ask-user'),
   background_tasks: surfaces('coding-tools.background-task'),
   browser: surfaces('coding-tools.browser'),
+  isolated_sandbox: surfaces('coding-tools.isolated-sandbox'),
 };
 
 export const BUILTIN_AGENT_TYPE_COVERAGE: Readonly<Record<string, CoverageDisposition>> = {


### PR DESCRIPTION
## 摘要
新增 Isolated sandbox（`exec` / `isolated_sandbox`）：QuickJS-WASI guest 可嵌套调用会话工具（含写入），中间读写不进对话，只有返回值留下。默认启用。

## 范围
- QuickJS guest runner + 工具桥（预算、禁嵌套 hire/wait/exec、shell 拒绝、输出 8KB 封顶）
- 设置开关、catalog、时间线/审批 UI（`exec › tool`、嵌套 pending）
- 子会话跟随父开关下发 `exec` + explore-fold，不含嵌套 hire
- read 截断 `totalLines` / 页脚对齐 `wc -l`

## 验证
`pnpm typecheck` 通过；相关 191 个测试通过。