### PR TITLE
style(compact): 收紧 summaryWindow 换行以通过 biome

### DIFF
--- a/src/agent/ensoCompact/extension.ts
+++ b/src/agent/ensoCompact/extension.ts
@@ -134,9 +134,7 @@ export function createEnsoCompactFactory(options: EnsoCompactOptions = {}) {
 
       const mode: CompactMode = options.mode ?? 'auto';
       const budget = BUDGETS[mode];
-      const summaryWindow = positiveWindow(
-        (model as { contextWindow?: unknown }).contextWindow
-      );
+      const summaryWindow = positiveWindow((model as { contextWindow?: unknown }).contextWindow);
       const singlePassMaxTokens = clampToModelWindow(budget.singlePassMaxTokens, summaryWindow);
       const maxChunkTokens = clampToModelWindow(budget.maxChunkTokens, summaryWindow);
       const previousSummary = preparation.previousSummary;


### PR DESCRIPTION
## 摘要
`pnpm lint` 因 `ensoCompact/extension.ts` 格式失败。一行收紧，无行为变化。