### PR TITLE
test: 缓解全量并行时的 5s 超时

### DIFF
--- a/packages/pair/src/direct/chunk.test.ts
+++ b/packages/pair/src/direct/chunk.test.ts
@@ -47,7 +47,11 @@ describe('DataChannel 分片编解码', () => {
     const chunks = encodeChunks(frame);
     expect(chunks.length).toBe(Math.ceil(1_000_000 / CHUNK_PAYLOAD_BYTES));
     for (const c of chunks) expect(c.byteLength).toBeLessThanOrEqual(CHUNK_PAYLOAD_BYTES + 1);
-    expect(roundTrip(frame)).toEqual(frame);
+    const r = createReassembler();
+    let got: Uint8Array | null = null;
+    for (const c of chunks) got = r.push(c) ?? got;
+    expect(got).not.toBeNull();
+    expect(Buffer.compare(got as Uint8Array, frame)).toBe(0);
   });
 
   it('中间片返回 null，末片才吐完整帧；连续两帧互不串', () => {

--- a/src/main/services/modelMeta.test.ts
+++ b/src/main/services/modelMeta.test.ts
@@ -31,7 +31,9 @@ afterAll(() => {
 });
 
 describe('queryModelMeta', () => {
-  it('订阅条目按 catalog 取值，contextWindow 与 runtime.getModel 一致', async () => {
+  it('订阅条目按 catalog 取值，contextWindow 与 runtime.getModel 一致', {
+    timeout: 20_000,
+  }, async () => {
     const { queryModelMeta } = await import('./modelMeta');
     const { getRuntime } = await import('./oauthProviders');
     const runtime = await getRuntime();

--- a/src/main/services/oauthProviders.test.ts
+++ b/src/main/services/oauthProviders.test.ts
@@ -80,7 +80,7 @@ afterAll(() => {
 });
 
 describe('listOauthProviders 的账号枚举', () => {
-  it('同一厂商的两个账号各占一行，裸 key 排在 #2 前面', async () => {
+  it('同一厂商的两个账号各占一行，裸 key 排在 #2 前面', { timeout: 20_000 }, async () => {
     const { listOauthProviders } = await import('./oauthProviders');
     const providers = await listOauthProviders();
     const anthropic = providers.find((provider) => provider.id === 'anthropic');


### PR DESCRIPTION
## 摘要
全量 `pnpm test` 与 worktree/checkpoint（约 109s）并行时，3 个用例会撞上默认 5s 超时。

## 改动
- 1MB 分片：复用已编码片 + `Buffer.compare`，不再对 1MB 做 `toEqual`（约 2s → 7ms）
- `modelMeta` / `oauthProviders` 首测加载 pi runtime：超时 20s